### PR TITLE
ci: Disable GitHub Catalina builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,11 +13,7 @@ jobs:
   test:
 
     name: Build macOS project
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ macos-latest, macos-big-sur ]
+    runs-on: macos-big-sur
 
     steps:
 


### PR DESCRIPTION
Since the Big Sur self-hosted runner builds npow seem reliable, it's OK to disable the GitHub Catalina builds.