### PR TITLE
feat: Reorder rule variables

### DIFF
--- a/macos/Fileaway/Core/RuleState.swift
+++ b/macos/Fileaway/Core/RuleState.swift
@@ -113,6 +113,22 @@ class RuleState: ObservableObject, Identifiable, CustomStringConvertible, Hashab
         destination.swapAt(index, index + 1)
     }
 
+    func moveUp(variable: VariableState) {
+        guard let index = variables.firstIndex(of: variable),
+              index > 0 else {
+            return
+        }
+        variables.swapAt(index, index - 1)
+    }
+
+    func moveDown(variable: VariableState) {
+        guard let index = variables.firstIndex(of: variable),
+              index < variables.count - 1 else {
+            return
+        }
+        variables.swapAt(index, index + 1)
+    }
+
     func remove(variable: VariableState) {
         variables.removeAll { $0 == variable }
     }

--- a/macos/Fileaway/Views/Settings/VariableList.swift
+++ b/macos/Fileaway/Views/Settings/VariableList.swift
@@ -60,6 +60,25 @@ struct VariableList: View {
                     }
                     .disabled(selection == nil)
                 }
+
+                ControlGroup {
+                    Button {
+                        guard let variable = selection else {
+                            return
+                        }
+                        rule.moveUp(variable: variable)
+                    } label: {
+                        Image(systemName: "arrow.up")
+                    }
+                    Button {
+                        guard let variable = selection else {
+                            return
+                        }
+                        rule.moveDown(variable: variable)
+                    } label: {
+                        Image(systemName: "arrow.down")
+                    }
+                }
                 
                 Spacer()
                     .layoutPriority(1)


### PR DESCRIPTION
It often makes sense to fill variables in in a specific order. This change allows them to be reordered in the rule editor.