### PR TITLE
fix: Update to the new SwiftUI list multi-selection support

### DIFF
--- a/macos/Fileaway/FileawayApp.swift
+++ b/macos/Fileaway/FileawayApp.swift
@@ -36,11 +36,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 }
 
 struct FocusedSelectionKey : FocusedValueKey {
-    typealias Value = Binding<Set<URL>>
-}
-
-struct FocusedIntKey : FocusedValueKey {
-    typealias Value = Binding<Int>
+    typealias Value = SelectionManager
 }
 
 extension FocusedValues {
@@ -48,22 +44,6 @@ extension FocusedValues {
     var selection: FocusedSelectionKey.Value? {
         get { self[FocusedSelectionKey.self] }
         set { self[FocusedSelectionKey.self] = newValue }
-    }
-
-    var item: FocusedIntKey.Value? {
-        get { self[FocusedIntKey.self] }
-        set { self[FocusedIntKey.self] = newValue }
-    }
-
-}
-
-struct GlobalCommands: Commands {
-
-    @FocusedBinding(\.item) var item: Int?
-
-    var body: some Commands {
-        ToolbarCommands()
-        SidebarCommands()
     }
 
 }
@@ -116,20 +96,10 @@ struct FileawayApp: App {
                 .frameAutosaveName("Main Window")
         }
         .commands {
-            GlobalCommands()
+            ToolbarCommands()
+            SidebarCommands()
         }
-        .onChange(of: phase) { phase in
-            switch phase {
-            case .active:
-                print("app state active")
-            case .background:
-                print("app state background")
-            case .inactive:
-                print("app state inactive")
-            @unknown default:
-                print("app state unknown")
-            }
-        }
+
         WindowGroup("Wizard") {
             RulesWizard()
                 .environment(\.manager, appDelegate.manager)
@@ -140,6 +110,7 @@ struct FileawayApp: App {
         }
         .windowStyle(HiddenTitleBarWindowStyle())
         .handlesExternalEvents(matching: Set(arrayLiteral: "*"))
+
         SwiftUI.Settings {
             SettingsView(manager: appDelegate.manager)
         }

--- a/macos/Fileaway/Modifiers/Toolbar.swift
+++ b/macos/Fileaway/Modifiers/Toolbar.swift
@@ -22,60 +22,55 @@ import SwiftUI
 
 import Interact
 
-struct Toolbar: ViewModifier {
+struct SelectionToolbar: CustomizableToolbarContent {
 
     @Environment(\.openURL) var openURL
 
     @ObservedObject var manager: SelectionManager
-    @Binding var filter: String
 
-    func body(content: Content) -> some View {
-        content
-            .toolbar {
-                ToolbarItem {
-                    Button {
-                        guard let file = manager.tracker.selection.first else {
-                            return
-                        }
-                        var components = URLComponents()
-                        components.scheme = "fileaway"
-                        components.path = file.url.path
-                        guard let url = components.url else {
-                            return
-                        }
-                        openURL(url)
-                    } label: {
-                        Image(systemName: "wand.and.stars")
-                    }
-                    .help("Move the selected items using the Rules Wizard")
-                    .disabled(!manager.canMove)
-                    .keyboardShortcut(KeyboardShortcut(.return, modifiers: .command))
+    var body: some CustomizableToolbarContent {
+        ToolbarItem(id: "wizard") {
+            Button {
+                guard let file = manager.selection.first else {
+                    return
                 }
-                ToolbarItem {
-                    Button {
-                        guard let file = manager.tracker.selection.first else {
-                            return
-                        }
-                        QuickLookCoordinator.shared.show(url: file.url)
-                    } label: {
-                        Image(systemName: "eye")
-                    }
-                    .help("Show items with Quick Look")
-                    .disabled(!manager.canPreview)
+                var components = URLComponents()
+                components.scheme = "fileaway"
+                components.path = file.url.path
+                guard let url = components.url else {
+                    return
                 }
-                ToolbarItem {
-                    Button {
-                        try? manager.trash()
-                    } label: {
-                        Image(systemName: "trash")
-                    }
-                    .help("Move the selected items to the Bin")
-                    .disabled(!manager.canTrash)
-                }
-                ToolbarItem {
-                    SearchField(search: $filter)
-                        .frame(minWidth: 100, idealWidth: 200, maxWidth: .infinity)
-                }
+                openURL(url)
+            } label: {
+                Image(systemName: "wand.and.stars")
             }
+            .help("Move the selected items using the Rules Wizard")
+            .keyboardShortcut(KeyboardShortcut(.return, modifiers: .command))
+            .disabled(!manager.canMove)
+        }
+        ToolbarItem(id: "preview") {
+            Button {
+                guard let file = manager.selection.first else {
+                    return
+                }
+                QuickLookCoordinator.shared.show(url: file.url)
+            } label: {
+                Label("Preview", systemImage: "eye")
+            }
+            .help("Show items with Quick Look")
+            .keyboardShortcut(.space, modifiers: [])
+            .disabled(!manager.canPreview)
+        }
+        ToolbarItem(id: "delete") {
+            Button {
+                try? manager.trash()
+            } label: {
+                Image(systemName: "trash")
+            }
+            .help("Move the selected items to the Bin")
+            .keyboardShortcut(.delete)
+            .disabled(!manager.canTrash)
+        }
     }
+
 }

--- a/macos/Fileaway/Utilities/SelectionManager.swift
+++ b/macos/Fileaway/Utilities/SelectionManager.swift
@@ -26,42 +26,47 @@ import Interact
 
 class SelectionManager: ObservableObject {
 
-    var tracker: SelectionTracker<FileInfo>
+    @Published var selection: Set<FileInfo> = []
+
     var cancellable: AnyCancellable? = nil
 
-    init(tracker: SelectionTracker<FileInfo>) {
-        self.tracker = tracker
-        cancellable = tracker.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        }
+    init() {
     }
 
     var urls: [URL] {
-        tracker.selection.map { $0.url }
+        selection.map { $0.url }
     }
 
-    var canPreview: Bool { !tracker.selection.isEmpty }
+    var canPreview: Bool {
+        return !selection.isEmpty
+    }
 
     func preview() {
-        guard let url = tracker.selection.first?.url else {
+        guard let url = selection.first?.url else {
             return
         }
         QuickLookCoordinator.shared.show(url: url)
     }
 
-    var canCut: Bool { !tracker.selection.isEmpty }
+    var canCut: Bool {
+        return !selection.isEmpty
+    }
 
     func cut() -> [NSItemProvider] {
         urls.map { NSItemProvider(object: $0 as NSURL) }
     }
 
-    var canTrash: Bool { !tracker.selection.isEmpty }
+    var canTrash: Bool {
+        return !selection.isEmpty
+    }
 
     func trash() throws {
         try urls.forEach { try FileManager.default.trashItem(at: $0, resultingItemURL: nil) }
     }
 
-    var canMove: Bool { !tracker.selection.isEmpty }
+    var canMove: Bool {
+        return !selection.isEmpty
+    }
 
     func open() {
         urls.forEach { url in

--- a/macos/Fileaway/Views/FileRow.swift
+++ b/macos/Fileaway/Views/FileRow.swift
@@ -25,34 +25,33 @@ import Interact
 
 struct FileRow: View {
 
-    var file: FileInfo
-    var isSelected: Bool
+    struct LayoutMetrics {
+        static let iconSize = CGSize(width: 48.0, height: 48.0)
+    }
 
-    init(file: FileInfo, isSelected: Bool) {
+    var file: FileInfo
+
+    init(file: FileInfo) {
         self.file = file
-        self.isSelected = isSelected
     }
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                IconView(url: file.url, size: CGSize(width: 48, height: 48))
+//                IconView(url: file.url, size: LayoutMetrics.iconSize)
                 VStack(spacing: 0) {
                     HStack {
                         Text(file.name)
                             .lineLimit(1)
                             .font(.headline)
-                            .foregroundColor(isSelected ? .white : .primary)
                         Spacer()
                         if let date = file.date {
                             DateView(date: date)
-                                .foregroundColor(isSelected ? .white : .secondary)
                         }
                     }
                     HStack {
                         Text(file.directoryUrl.path)
                             .lineLimit(1)
-                            .foregroundColor(isSelected ? .white : .secondary)
                             .font(.subheadline)
                         Spacer()
                     }


### PR DESCRIPTION
This change temporarily removes the icons as the current implementation performs poorly now we're using `List`. It also makes no attempt to clean up the layout issues resulting from the update to target macOS Ventura.