### PR TITLE
fix: Use the new SwiftUI mechanism for opening new windows

### DIFF
--- a/macos/Fileaway/FileawayApp.swift
+++ b/macos/Fileaway/FileawayApp.swift
@@ -90,26 +90,17 @@ struct FileawayApp: App {
     }
 
     var body: some Scene {
+        
         WindowGroup(id: "MainWindow") {
             ContentView(manager: appDelegate.manager)
                 .environment(\.manager, appDelegate.manager)
-                .frameAutosaveName("Main Window")
         }
         .commands {
             ToolbarCommands()
             SidebarCommands()
         }
 
-        WindowGroup("Wizard") {
-            RulesWizard()
-                .environment(\.manager, appDelegate.manager)
-                .handlesExternalEvents(preferring: Set(arrayLiteral: "*"), allowing: Set(arrayLiteral: "*"))
-                .background(VisualEffectView(material: NSVisualEffectView.Material.sidebar,
-                                             blendingMode: NSVisualEffectView.BlendingMode.behindWindow)
-                                .edgesIgnoringSafeArea(.all))
-        }
-        .windowStyle(HiddenTitleBarWindowStyle())
-        .handlesExternalEvents(matching: Set(arrayLiteral: "*"))
+        Wizard(manager: appDelegate.manager)
 
         SwiftUI.Settings {
             SettingsView(manager: appDelegate.manager)
@@ -124,4 +115,25 @@ struct FileawayApp: App {
         }
 
     }
+}
+
+struct Wizard: Scene {
+
+    static let windowID = "wizard-window"
+
+    var manager: Manager
+
+    var body: some Scene {
+        WindowGroup(id: Self.windowID, for: URL.self) { $url in
+            if let url = url {
+                RulesWizard(url: url)
+                    .environment(\.manager, manager)
+                    .background(VisualEffectView(material: NSVisualEffectView.Material.sidebar,
+                                                 blendingMode: NSVisualEffectView.BlendingMode.behindWindow)
+                        .edgesIgnoringSafeArea(.all))
+            }
+        }
+        .windowStyle(.hiddenTitleBar)
+    }
+
 }

--- a/macos/Fileaway/Modifiers/Toolbar.swift
+++ b/macos/Fileaway/Modifiers/Toolbar.swift
@@ -24,7 +24,7 @@ import Interact
 
 struct SelectionToolbar: CustomizableToolbarContent {
 
-    @Environment(\.openURL) var openURL
+    @Environment(\.openWindow) var openWindow
 
     @ObservedObject var manager: SelectionManager
 
@@ -34,13 +34,7 @@ struct SelectionToolbar: CustomizableToolbarContent {
                 guard let file = manager.selection.first else {
                     return
                 }
-                var components = URLComponents()
-                components.scheme = "fileaway"
-                components.path = file.url.path
-                guard let url = components.url else {
-                    return
-                }
-                openURL(url)
+                openWindow(id: Wizard.windowID, value: file.url)
             } label: {
                 Image(systemName: "wand.and.stars")
             }

--- a/macos/Fileaway/Views/DirectoryView.swift
+++ b/macos/Fileaway/Views/DirectoryView.swift
@@ -28,7 +28,7 @@ import Interact
 
 struct DirectoryView: View {
 
-    @Environment(\.openURL) var openURL
+    @Environment(\.openWindow) var openWindow
 
     @ObservedObject var directoryObserver: DirectoryObserver
 
@@ -48,13 +48,7 @@ struct DirectoryView: View {
             if selection.count == 1, let file = selection.first {
 
                 Button("Rules Wizard") {
-                    var components = URLComponents()
-                    components.scheme = "fileaway"
-                    components.path = file.url.path
-                    guard let url = components.url else {
-                        return
-                    }
-                    openURL(url)
+                    openWindow(id: Wizard.windowID, value: file.url)
                 }
                 Divider()
                 Button("Open") {

--- a/macos/Fileaway/Views/Wizard/RulesWizard.swift
+++ b/macos/Fileaway/Views/Wizard/RulesWizard.swift
@@ -23,25 +23,17 @@ import SwiftUI
 struct RulesWizard: View {
 
     @Environment(\.manager) var manager
-    @SceneStorage("RulesWizard.documentUrl") var url: URL?
+    @State var url: URL
     @State var firstResponder: Bool = true
 
     var body: some View {
-        VStack {
-            if let url = url {
-                HStack {
-                    QuickLookPreview(url: url)
-                        .onTapGesture(count: 2) {
-                            NSWorkspace.shared.open(url)
-                        }
-                    PageView {
-                        TaskPage(manager: manager, url: url)
-                    }
+        HStack {
+            QuickLookPreview(url: url)
+                .onTapGesture(count: 2) {
+                    NSWorkspace.shared.open(url)
                 }
-            } else {
-                Text("No File Selected")
-                    .font(.largeTitle)
-                    .foregroundColor(.secondary)
+            PageView {
+                TaskPage(manager: manager, url: url)
             }
         }
         .acceptsFirstResponder(isFirstResponder: $firstResponder)


### PR DESCRIPTION
This fixes the bug where the wizard might open in the wrong version of Fileaway if multiple development copies were installed.