### PR TITLE
refactor: Move `TaskPageModel` into a separate file

### DIFF
--- a/core/Sources/FileawayCore/Model/SelectionModel.swift
+++ b/core/Sources/FileawayCore/Model/SelectionModel.swift
@@ -100,7 +100,6 @@ public class SelectionModel: ObservableObject {
     public func open() {
         urls.forEach { url in
             openURL(url)
-//            NSWorkspace.shared.open(url)
         }
     }
 

--- a/macos/Fileaway-macOS.xcodeproj/project.pbxproj
+++ b/macos/Fileaway-macOS.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		D8037B122617F8CD00F41971 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = D8037B112617F8CD00F41971 /* Introspect */; };
 		D80F72D826430E3C0010BB38 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F72D726430E3C0010BB38 /* Data.swift */; };
 		D81B24112918267E0078D638 /* TaskPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B24102918267E0078D638 /* TaskPageModel.swift */; };
+		D81B2413291828090078D638 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B2412291828090078D638 /* UserDefaults.swift */; };
 		D821E939257A959D005D3205 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D821E938257A959D005D3205 /* DateView.swift */; };
 		D821E946257AA5FC005D3205 /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D821E945257AA5FC005D3205 /* Sidebar.swift */; };
 		D821E94B257AB2C9005D3205 /* FileRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D821E94A257AB2C9005D3205 /* FileRow.swift */; };
@@ -78,6 +79,7 @@
 /* Begin PBXFileReference section */
 		D80F72D726430E3C0010BB38 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		D81B24102918267E0078D638 /* TaskPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskPageModel.swift; sourceTree = "<group>"; };
+		D81B2412291828090078D638 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		D821E938257A959D005D3205 /* DateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
 		D821E945257AA5FC005D3205 /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		D821E94A257AB2C9005D3205 /* FileRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRow.swift; sourceTree = "<group>"; };
@@ -285,8 +287,9 @@
 		D87DEFC2257848A7006CFE85 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				D87DEFC3257848B7006CFE85 /* URL.swift */,
 				D80F72D726430E3C0010BB38 /* Data.swift */,
+				D87DEFC3257848B7006CFE85 /* URL.swift */,
+				D81B2412291828090078D638 /* UserDefaults.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -500,6 +503,7 @@
 				D82D01282657F69900FD2974 /* Observable.swift in Sources */,
 				D821E946257AA5FC005D3205 /* Sidebar.swift in Sources */,
 				D8F8BE12258818450010432F /* RulesWizard.swift in Sources */,
+				D81B2413291828090078D638 /* UserDefaults.swift in Sources */,
 				D82D01222657632C00FD2974 /* VariableDateView.swift in Sources */,
 				D87DEF7F25774F6C006CFE85 /* FileawayApp.swift in Sources */,
 				D87DEFB925783F66006CFE85 /* DirectoryView.swift in Sources */,

--- a/macos/Fileaway-macOS.xcodeproj/project.pbxproj
+++ b/macos/Fileaway-macOS.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		D8037B122617F8CD00F41971 /* Introspect in Frameworks */ = {isa = PBXBuildFile; productRef = D8037B112617F8CD00F41971 /* Introspect */; };
 		D80F72D826430E3C0010BB38 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80F72D726430E3C0010BB38 /* Data.swift */; };
+		D81B24112918267E0078D638 /* TaskPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81B24102918267E0078D638 /* TaskPageModel.swift */; };
 		D821E939257A959D005D3205 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D821E938257A959D005D3205 /* DateView.swift */; };
 		D821E946257AA5FC005D3205 /* Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D821E945257AA5FC005D3205 /* Sidebar.swift */; };
 		D821E94B257AB2C9005D3205 /* FileRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D821E94A257AB2C9005D3205 /* FileRow.swift */; };
@@ -76,6 +77,7 @@
 
 /* Begin PBXFileReference section */
 		D80F72D726430E3C0010BB38 /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		D81B24102918267E0078D638 /* TaskPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskPageModel.swift; sourceTree = "<group>"; };
 		D821E938257A959D005D3205 /* DateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
 		D821E945257AA5FC005D3205 /* Sidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar.swift; sourceTree = "<group>"; };
 		D821E94A257AB2C9005D3205 /* FileRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRow.swift; sourceTree = "<group>"; };
@@ -329,6 +331,7 @@
 				D8F8BE1C2588192F0010432F /* DetailsPage.swift */,
 				D8F8BE11258818450010432F /* RulesWizard.swift */,
 				D8F8BE3625881C1A0010432F /* TaskPage.swift */,
+				D81B24102918267E0078D638 /* TaskPageModel.swift */,
 			);
 			path = Wizard;
 			sourceTree = "<group>";
@@ -504,6 +507,7 @@
 				D8B657E826421D5B009DE837 /* LocationMenuItems.swift in Sources */,
 				D829DDB425787C100066A807 /* Settings.swift in Sources */,
 				D87DEFBE257840B1006CFE85 /* ApplicationModel.swift in Sources */,
+				D81B24112918267E0078D638 /* TaskPageModel.swift in Sources */,
 				D82D012A2657F6D500FD2974 /* TextProvider.swift in Sources */,
 				D82D01242657637700FD2974 /* VariableStringView.swift in Sources */,
 				D8E7F9EB2599B05300C7409B /* VariableList.swift in Sources */,

--- a/macos/Fileaway/Extensions/UserDefaults.swift
+++ b/macos/Fileaway/Extensions/UserDefaults.swift
@@ -18,29 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import SwiftUI
+import Foundation
 
-class Settings: ObservableObject {
+extension UserDefaults {
 
-    static let inboxUrls = "inbox-urls"
-    static let archiveUrls = "archive-urls"
-
-    @Published var inboxUrls: [URL] = []
-    @Published var archiveUrls: [URL] = []
-
-    init() {
-        inboxUrls = (try? UserDefaults.standard.securityScopeUrls(forKey: Self.inboxUrls)) ?? []
-        archiveUrls = (try? UserDefaults.standard.securityScopeUrls(forKey: Self.archiveUrls)) ?? []
-    }
-
-    func setInboxUrls(_ urls: [URL]) throws {
-        let bookmarks = try urls.map { try $0.securityScopeBookmarkData() }
-        UserDefaults.standard.set(bookmarks, forKey: Self.inboxUrls);
-    }
-
-    func setArchiveUrls(_ urls: [URL]) throws {
-        let bookmarks = try urls.map { try $0.securityScopeBookmarkData() }
-        UserDefaults.standard.set(bookmarks, forKey: Self.archiveUrls);
+    func securityScopeUrls(forKey defaultName: String) throws -> [URL] {
+        guard let urls = UserDefaults.standard.array(forKey: defaultName) as? [Data] else {
+            return []
+        }
+        return try urls.map { try $0.asSecurityScopeUrl() }
     }
 
 }

--- a/macos/Fileaway/Views/Wizard/DetailsPage.swift
+++ b/macos/Fileaway/Views/Wizard/DetailsPage.swift
@@ -24,7 +24,17 @@ import FileawayCore
 
 struct DetailsPage: View {
 
-    enum AlertType {
+    enum AlertType: Identifiable {
+
+        public var id: String {
+            switch self {
+            case .error(let error):
+                return "error:\(error)"
+            case .duplicate(let duplicateUrl):
+                return "duplicate:\(duplicateUrl)"
+            }
+        }
+
         case error(error: Error)
         case duplicate(duplicateUrl: URL)
     }
@@ -106,17 +116,4 @@ struct DetailsPage: View {
         }
     }
 
-}
-
-extension DetailsPage.AlertType: Identifiable {
-
-    public var id: String {
-        switch self {
-        case .error(let error):
-            return "error:\(error)"
-        case .duplicate(let duplicateUrl):
-            return "duplicate:\(duplicateUrl)"
-        }
-    }
-    
 }

--- a/macos/Fileaway/Views/Wizard/TaskPage.swift
+++ b/macos/Fileaway/Views/Wizard/TaskPage.swift
@@ -24,49 +24,6 @@ import SwiftUI
 import FileawayCore
 import Interact
 
-class TaskPageModel: ObservableObject {
-
-    @Published var filter: String = ""
-    @Published var filteredRules: [Rule] = []
-    @Published var selection: Rule.ID?
-
-    private var manager: ApplicationModel
-    private var cancellables: Set<AnyCancellable> = []
-    private var queue = DispatchQueue(label: "queue")
-
-    init(manager: ApplicationModel) {
-        self.manager = manager
-    }
-
-    @MainActor func start() {
-
-        manager
-            .$allRules
-            .combineLatest($filter)
-            .receive(on: queue)
-            .map { rules, filter in
-                guard !filter.isEmpty else {
-                    return rules
-                }
-                return rules.filter { item in
-                    [item.rootUrl.displayName, item.name].joined(separator: " ").localizedSearchMatches(string: filter)
-                }
-            }
-            .map { $0.sorted { lhs, rhs in lhs.name.lexicographicallyPrecedes(rhs.name) } }
-            .receive(on: DispatchQueue.main)
-            .sink { rules in
-                self.filteredRules = rules
-                self.selection = rules.first?.id
-            }
-            .store(in: &cancellables)
-    }
-
-    @MainActor func stop() {
-        cancellables.removeAll()
-    }
-
-}
-
 struct TaskPage: View {
 
     enum FocusableField: Hashable {

--- a/macos/Fileaway/Views/Wizard/TaskPageModel.swift
+++ b/macos/Fileaway/Views/Wizard/TaskPageModel.swift
@@ -1,0 +1,67 @@
+// Copyright (c) 2018-2022 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Combine
+import SwiftUI
+
+import FileawayCore
+
+class TaskPageModel: ObservableObject {
+
+    @Published var filter: String = ""
+    @Published var filteredRules: [Rule] = []
+    @Published var selection: Rule.ID?
+
+    private var manager: ApplicationModel
+    private var cancellables: Set<AnyCancellable> = []
+    private var queue = DispatchQueue(label: "queue")
+
+    init(manager: ApplicationModel) {
+        self.manager = manager
+    }
+
+    @MainActor func start() {
+
+        manager
+            .$allRules
+            .combineLatest($filter)
+            .receive(on: queue)
+            .map { rules, filter in
+                guard !filter.isEmpty else {
+                    return rules
+                }
+                return rules.filter { item in
+                    [item.rootUrl.displayName, item.name].joined(separator: " ").localizedSearchMatches(string: filter)
+                }
+            }
+            .map { $0.sorted { lhs, rhs in lhs.name.lexicographicallyPrecedes(rhs.name) } }
+            .receive(on: DispatchQueue.main)
+            .sink { rules in
+                self.filteredRules = rules
+                self.selection = rules.first?.id
+            }
+            .store(in: &cancellables)
+    }
+
+    @MainActor func stop() {
+        cancellables.removeAll()
+    }
+
+}


### PR DESCRIPTION
This also includes drive-by fixes to move the `UserDefaults` extension into a separate file and remove some commented out code.