### PR TITLE
fix: Ensure the iOS app stores rules in the correct format

### DIFF
--- a/core/Sources/FileawayCore/Configuration/Rule.swift
+++ b/core/Sources/FileawayCore/Configuration/Rule.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-public struct Configuration: Codable {
+public struct Rule: Codable {
 
     enum CodingKeys: CodingKey {
         case id

--- a/core/Sources/FileawayCore/Configuration/RuleList.swift
+++ b/core/Sources/FileawayCore/Configuration/RuleList.swift
@@ -20,32 +20,32 @@
 
 import Foundation
 
-public struct ConfigurationList: Codable {
+public struct RuleList: Codable {
 
-    let items: [Configuration]
+    let rules: [Rule]
 
     public init() {
-        self.items = []
+        self.rules = []
     }
 
-    public init(items: [Configuration]) {
-        self.items = items
+    public init(rules: [Rule]) {
+        self.rules = rules
     }
 
     public init(url: URL) throws {
         let data = try Data(contentsOf: url)
         let decoder = JSONDecoder()
-        self = try decoder.decode(ConfigurationList.self, from: data)
+        self = try decoder.decode(RuleList.self, from: data)
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.items = try container.decode([Configuration].self)
+        self.rules = try container.decode([Rule].self)
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(items)
+        try container.encode(rules)
     }
 
 }

--- a/core/Sources/FileawayCore/Configuration/Task.swift
+++ b/core/Sources/FileawayCore/Configuration/Task.swift
@@ -22,9 +22,9 @@ import Foundation
 
 public struct Task {
     public let name: String
-    public let configuration: Configuration
-    public init(name: String, configuration: Configuration) {
+    public let rule: Rule
+    public init(name: String, rule: Rule) {
         self.name = name
-        self.configuration = configuration
+        self.rule = rule
     }
 }

--- a/core/Sources/FileawayCore/Manager.swift
+++ b/core/Sources/FileawayCore/Manager.swift
@@ -50,25 +50,25 @@ public class Manager {
     static func load(_ url: URL) throws -> [Task] {
         let data = try Data(contentsOf: url)
         let decoder = JSONDecoder()
-        let configurationList = try decoder.decode(ConfigurationList.self, from: data)
-        let tasks = configurationList.items.map { configuration -> Task in
-            return Task(name: configuration.name, configuration: configuration)
-            }.sorted { (task0, task1) -> Bool in
-                return task0.name < task1.name
+        let configurationList = try decoder.decode(RuleList.self, from: data)
+        let tasks = configurationList.rules.map { rule -> Task in
+            return Task(name: rule.name, rule: rule)
+        }.sorted { (task0, task1) -> Bool in
+            return task0.name < task1.name
         }
         return tasks
-           }
+    }
 
-           public func destinationUrl(_ task: Task, variableProvider: VariableProvider, rootUrl: URL? = nil) -> URL {
-               let destination = task.configuration.destination.reduce("") { (result, component) -> String in
-                   switch component.type {
-                   case .text:
-                       return result.appending(component.value)
-                   case .variable:
-                       guard let value = variableProvider.variable(forKey: component.value) else {
-                           return result
-                       }
-                       return result.appending(value)
+    public func destinationUrl(_ task: Task, variableProvider: VariableProvider, rootUrl: URL? = nil) -> URL {
+        let destination = task.rule.destination.reduce("") { (result, component) -> String in
+            switch component.type {
+            case .text:
+                return result.appending(component.value)
+            case .variable:
+                guard let value = variableProvider.variable(forKey: component.value) else {
+                    return result
+                }
+                return result.appending(value)
             }
         }
         let actualRootUrl = rootUrl ?? self.rootUrl

--- a/core/Sources/FileawayCore/Model/RulesModel.swift
+++ b/core/Sources/FileawayCore/Model/RulesModel.swift
@@ -35,7 +35,7 @@ public class RulesModel: ObservableObject {
         self.url = url.appendingPathComponent("Rules.fileaway")
         if FileManager.default.fileExists(atPath: self.url.path) {
             do {
-                self.mutableRules = try ConfigurationList(url: self.url).models(for: self.rootUrl)
+                self.mutableRules = try RuleList(url: self.url).models(for: self.rootUrl)
             } catch {
                 // TODO: Propagate this error!
                 print("Failed to load rules with error \(error).")
@@ -125,7 +125,7 @@ public class RulesModel: ObservableObject {
 
     private func save() throws {
         dispatchPrecondition(condition: .onQueue(.main))
-        let configurationList = ConfigurationList(rules: mutableRules)
+        let configurationList = RuleList(ruleModels: mutableRules)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(configurationList)
@@ -134,7 +134,7 @@ public class RulesModel: ObservableObject {
     
 }
 
-extension Configuration {
+extension Rule {
 
     public init(_ ruleModel: RuleModel) {
         self.init(id: ruleModel.id,
@@ -145,15 +145,15 @@ extension Configuration {
 
 }
 
-extension ConfigurationList {
+extension RuleList {
 
-    init(rules: [RuleModel]) {
-        items = rules
-            .map { Configuration($0) }
+    init(ruleModels: [RuleModel]) {
+        rules = ruleModels
+            .map { Rule($0) }
     }
 
     func models(for rootUrl: URL) -> [RuleModel] {
-        return items
+        return rules
             .map { configuration -> RuleModel in
                 let variables = configuration.variables.map { VariableModel($0) }
                 return RuleModel(id: configuration.id,

--- a/core/Sources/FileawayCore/Model/TaskModel.swift
+++ b/core/Sources/FileawayCore/Model/TaskModel.swift
@@ -80,9 +80,9 @@ public class TaskModel: ObservableObject, Identifiable, BackChannelable, CustomS
     public init(task: Task) {
         self.id = UUID()
         self.name = task.name
-        let variables = task.configuration.variables.map { VariableModel($0) }
+        let variables = task.rule.variables.map { VariableModel($0) }
         self.variables = variables
-        self.destination = task.configuration.destination.map { component in
+        self.destination = task.rule.destination.map { component in
             ComponentModel(component, variable: variables.first { $0.name == component.value } )
         }
     }
@@ -147,10 +147,10 @@ extension Task {
 
     public init(_ taskModel: TaskModel) {
         self.init(name: taskModel.name,
-                  configuration: Configuration(id: taskModel.id,
-                                               name: taskModel.name,
-                                               variables: taskModel.variables.map { Variable($0) },
-                                               destination: taskModel.destination.map { Component($0) }))
+                  rule: Rule(id: taskModel.id,
+                             name: taskModel.name,
+                             variables: taskModel.variables.map { Variable($0) },
+                             destination: taskModel.destination.map { Component($0) }))
     }
 
 }

--- a/ios/Fileaway/Settings.swift
+++ b/ios/Fileaway/Settings.swift
@@ -55,13 +55,13 @@ class LegacySettings: ObservableObject {
             tasks.establishBackChannel()
             taskObserver = tasks.onChange {
                 let tasks = self.tasks.tasks.map { Task($0) }
-                let configuration = tasks.reduce(into: [:]) { result, task in
-                    result[task.name] = task.configuration
+                let rules = tasks.map { task in
+                    return task.rule
                 }
                 do {
                     let encoder = JSONEncoder()
                     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-                    let data = try encoder.encode(configuration)
+                    let data = try encoder.encode(RuleList(rules: rules))
                     let configurationUrl = try StorageManager.configurationUrl()
                     try data.write(to: configurationUrl)
                     // TODO: Remove this hack to reload the manager.

--- a/ios/Fileaway/View Controllers/PickerViewController.swift
+++ b/ios/Fileaway/View Controllers/PickerViewController.swift
@@ -59,14 +59,14 @@ class EditableSection: VariableProvider {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let variable = task.configuration.variables[indexPath.row]
+        let variable = task.rule.variables[indexPath.row]
         switch (variable.type) {
         case .string:
             let cell = tableView.dequeueReusableCell(withIdentifier: ReuseIdentifier.textCell.rawValue, for: indexPath)
             guard let textCell = cell as? TextTableViewCell else {
                 return cell
             }
-            textCell.variable = task.configuration.variables[indexPath.row]
+            textCell.variable = task.rule.variables[indexPath.row]
             textCell.textField.text = values[variable.name] as? String
             textCell.delegate = self
             return textCell
@@ -75,7 +75,7 @@ class EditableSection: VariableProvider {
             guard let dateCell = cell as? DateTableViewCell else {
                 return cell
             }
-            dateCell.variable = task.configuration.variables[indexPath.row]
+            dateCell.variable = task.rule.variables[indexPath.row]
             dateCell.datePicker.date = (values[variable.name] as? Date) ?? Date()
             dateCell.delegate = self
             return dateCell
@@ -84,7 +84,7 @@ class EditableSection: VariableProvider {
     }
 
     var count: Int {
-        return task.configuration.variables.count
+        return task.rule.variables.count
     }
 
 }


### PR DESCRIPTION
This also includes a drive-by refactor to reanem `Configuration` and `ConfigurationList` to `Rule` and `RuleList`.