### PR TITLE
fix: Refresh iOS folders when foregrounding the app

### DIFF
--- a/core/Sources/FileawayCore/Model/ApplicationModel.swift
+++ b/core/Sources/FileawayCore/Model/ApplicationModel.swift
@@ -26,19 +26,6 @@ import SwiftUI
 import AppKit
 #endif
 
-public struct ApplicationModelKey: EnvironmentKey {
-    @MainActor public static var defaultValue: ApplicationModel = ApplicationModel()
-}
-
-extension EnvironmentValues {
-
-    public var applicationModel: ApplicationModel {
-        get { self[ApplicationModelKey.self] }
-        set { self[ApplicationModelKey.self] = newValue }
-    }
-
-}
-
 public class ApplicationModel: ObservableObject {
 
     public let settings = Settings()

--- a/core/Sources/FileawayCore/Views/Viewer/LocationMenuItems.swift
+++ b/core/Sources/FileawayCore/Views/Viewer/LocationMenuItems.swift
@@ -22,7 +22,7 @@ import SwiftUI
 
 public struct LocationMenuItems: View {
 
-    @Environment(\.applicationModel) private var applicationModel
+    @EnvironmentObject private var applicationModel: ApplicationModel
     @EnvironmentObject private var sceneModel: SceneModel
 
     private var url: URL

--- a/core/Sources/FileawayCore/Views/Viewer/LocationRow.swift
+++ b/core/Sources/FileawayCore/Views/Viewer/LocationRow.swift
@@ -24,7 +24,7 @@ import FilePicker
 
 struct LocationRow: View {
 
-    @Environment(\.applicationModel) private var applicationModel
+    @EnvironmentObject private var applicationModel: ApplicationModel
     @ObservedObject var directoryViewModel: DirectoryViewModel
 
     var body: some View {

--- a/core/Sources/FileawayCore/Views/Viewer/LocationSection.swift
+++ b/core/Sources/FileawayCore/Views/Viewer/LocationSection.swift
@@ -24,7 +24,7 @@ import FilePicker
 
 public struct LocationSection: View {
 
-    @Environment(\.applicationModel) private var applicationModel
+    @EnvironmentObject private var applicationModel: ApplicationModel
 
 #if os(iOS)
     @Environment(\.editMode) private var editMode

--- a/core/Sources/FileawayCore/Views/Viewer/Sidebar.swift
+++ b/core/Sources/FileawayCore/Views/Viewer/Sidebar.swift
@@ -22,7 +22,7 @@ import SwiftUI
 
 public struct Sidebar: View {
 
-    @Environment(\.applicationModel) var applicationModel
+    @EnvironmentObject private var applicationModel: ApplicationModel
     @ObservedObject var sceneModel: SceneModel
 
     public init(sceneModel: SceneModel) {

--- a/ios/Fileaway/FileawayApp.swift
+++ b/ios/Fileaway/FileawayApp.swift
@@ -31,7 +31,7 @@ struct AnytimeApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView(applicationModel: applicationModel)
-                .environment(\.applicationModel, applicationModel)
+                .environmentObject(applicationModel)
         }
     }
 

--- a/ios/Fileaway/Views/Wizard/RulePicker.swift
+++ b/ios/Fileaway/Views/Wizard/RulePicker.swift
@@ -25,8 +25,8 @@ import FileawayCore
 struct RulePicker: View {
 
     @Environment(\.dismiss) var dismiss
-    @Environment(\.applicationModel) var applicationModel
 
+    @EnvironmentObject private var applicationModel: ApplicationModel
     @StateObject var rulePickerModel: RulePickerModel
 
     private let url: URL

--- a/ios/Fileaway/Views/Wizard/RulePickerRow.swift
+++ b/ios/Fileaway/Views/Wizard/RulePickerRow.swift
@@ -24,7 +24,7 @@ import FileawayCore
 
 struct RulePickerRow: View {
 
-    @Environment(\.applicationModel) var applicationModel
+    @EnvironmentObject private var applicationModel: ApplicationModel
 
     private let url: URL
     private let ruleModel: RuleModel

--- a/ios/Fileaway/Views/Wizard/WizardView.swift
+++ b/ios/Fileaway/Views/Wizard/WizardView.swift
@@ -24,9 +24,9 @@ import FileawayCore
 
 struct WizardView: View {
 
-    @Environment(\.applicationModel) var applicationModel
     @Environment(\.dismiss) var dismiss
 
+    @EnvironmentObject private var applicationModel: ApplicationModel
     @StateObject var wizardModel = WizardModel()
 
     let file: FileInfo

--- a/macos/Fileaway/FileawayApp.swift
+++ b/macos/Fileaway/FileawayApp.swift
@@ -49,7 +49,7 @@ struct FileawayApp: App {
         
         WindowGroup(id: "main") {
             ContentView(applicationModel: applicationModel)
-                .environment(\.applicationModel, applicationModel)
+                .environmentObject(applicationModel)
         }
         .commands {
             ToolbarCommands()

--- a/macos/Fileaway/Scenes/Wizard.swift
+++ b/macos/Fileaway/Scenes/Wizard.swift
@@ -36,7 +36,7 @@ struct Wizard: Scene {
         WindowGroup(id: Self.windowID, for: URL.self) { $url in
             if let url = url {
                 WizardView(url: url)
-                    .environment(\.applicationModel, applicationModel)
+                    .environmentObject(applicationModel)
             }
         }
     }

--- a/macos/Fileaway/Toolbars/SelectionToolbar.swift
+++ b/macos/Fileaway/Toolbars/SelectionToolbar.swift
@@ -26,9 +26,9 @@ import FileawayCore
 
 struct SelectionToolbar: CustomizableToolbarContent {
 
-    @Environment(\.applicationModel) var manager
     @Environment(\.openWindow) var openWindow
 
+    @EnvironmentObject private var applicationModel: ApplicationModel
     @ObservedObject var directoryViewModel: DirectoryViewModel
 
     var body: some CustomizableToolbarContent {

--- a/macos/Fileaway/Views/Settings/GeneralSettingsView.swift
+++ b/macos/Fileaway/Views/Settings/GeneralSettingsView.swift
@@ -24,7 +24,7 @@ import FileawayCore
 
 struct GeneralSettingsView: View {
 
-    @Environment(\.applicationModel) var applicationModel: ApplicationModel
+    @EnvironmentObject private var applicationModel: ApplicationModel
 
     var body: some View {
         FileTypesView(settings: applicationModel.settings)

--- a/macos/Fileaway/Views/Wizard/WizardView.swift
+++ b/macos/Fileaway/Views/Wizard/WizardView.swift
@@ -34,7 +34,7 @@ class RulesWizardModel: ObservableObject {
 
 struct WizardView: View {
 
-    @Environment(\.applicationModel) var applicationModel
+    @EnvironmentObject private var applicationModel: ApplicationModel
 
     @StateObject var rulesWizardModel = RulesWizardModel()
 


### PR DESCRIPTION
This change also includes a drive-by fix to a bug which led to duplicate `ApplicationModel` instances, causing unnecessary directory indexing.