### PR TITLE
refactor: Clean up the URL naming

### DIFF
--- a/core/Sources/FileawayCore/Model/RuleFormModel.swift
+++ b/core/Sources/FileawayCore/Model/RuleFormModel.swift
@@ -48,7 +48,7 @@ public class RuleFormModel: ObservableObject, Runnable {
                 return result.appending(variable.textRepresentation)
             }
         }
-        return self.ruleModel.rootUrl.appendingPathComponent(destination).appendingPathExtension(url.pathExtension)
+        return self.ruleModel.archiveURL.appendingPathComponent(destination).appendingPathExtension(url.pathExtension)
     }
 
     public init(applicationModel: ApplicationModel, ruleModel: RuleModel, url: URL) {
@@ -67,9 +67,9 @@ public class RuleFormModel: ObservableObject, Runnable {
         bold.font = font.bold()
 
         var result = AttributedString()
-        result.append(AttributedString(ruleModel.rootUrl.displayName, attributes: bold))
+        result.append(AttributedString(ruleModel.archiveURL.displayName, attributes: bold))
         result.append(AttributedString("/", attributes: regular))
-        result.append(AttributedString(destinationURL.relativePath(from: ruleModel.rootUrl)!, attributes: regular))
+        result.append(AttributedString(destinationURL.relativePath(from: ruleModel.archiveURL)!, attributes: regular))
         return result
     }
 

--- a/core/Sources/FileawayCore/Model/RuleModel.swift
+++ b/core/Sources/FileawayCore/Model/RuleModel.swift
@@ -28,7 +28,7 @@ public class RuleModel: ObservableObject, Identifiable, CustomStringConvertible,
     }
 
     public let id: UUID
-    public let rootUrl: URL
+    public let archiveURL: URL
 
     @Published public var name: String
     @Published public var variables: [VariableModel]
@@ -65,7 +65,7 @@ public class RuleModel: ObservableObject, Identifiable, CustomStringConvertible,
 
     public init(id: UUID, rootUrl: URL, name: String, variables: [VariableModel], destination: [ComponentModel]) {
         self.id = id
-        self.rootUrl = rootUrl
+        self.archiveURL = rootUrl
         self.name = name
         self.variables = variables
         self.destination = destination
@@ -81,7 +81,7 @@ public class RuleModel: ObservableObject, Identifiable, CustomStringConvertible,
 
     public convenience init(_ ruleModel: RuleModel) {
         self.init(id: ruleModel.id,
-                  rootUrl: ruleModel.rootUrl,
+                  rootUrl: ruleModel.archiveURL,
                   name: String(ruleModel.name),
                   variables: ruleModel.variables,
                   destination: ruleModel.destination.map { ComponentModel($0, variable: nil) })
@@ -89,7 +89,7 @@ public class RuleModel: ObservableObject, Identifiable, CustomStringConvertible,
 
     public convenience init(id: UUID, ruleModel: RuleModel) {
         self.init(id: id,
-                  rootUrl: ruleModel.rootUrl,
+                  rootUrl: ruleModel.archiveURL,
                   name: String(ruleModel.name),
                   variables: ruleModel.variables,
                   destination: ruleModel.destination.map { ComponentModel($0, variable: nil) })

--- a/core/Sources/FileawayCore/Model/RuleModel.swift
+++ b/core/Sources/FileawayCore/Model/RuleModel.swift
@@ -207,3 +207,31 @@ public class RuleModel: ObservableObject, Identifiable, CustomStringConvertible,
     }
 
 }
+
+extension Rule {
+
+    public init(_ ruleModel: RuleModel) {
+        self.init(id: ruleModel.id,
+                  name: ruleModel.name,
+                  variables: ruleModel.variables,
+                  destination: ruleModel.destination.map { Component($0) })
+    }
+
+}
+
+extension RuleList {
+
+    init(ruleModels: [RuleModel]) {
+        rules = ruleModels
+            .map { Rule($0) }
+    }
+
+    func models(for rootUrl: URL) -> [RuleModel] {
+        return rules
+            .map { rule in
+                return RuleModel(rootUrl: rootUrl, rule: rule)
+            }
+            .sorted { $0.name < $1.name }
+    }
+
+}

--- a/core/Sources/FileawayCore/Model/RulePickerModel.swift
+++ b/core/Sources/FileawayCore/Model/RulePickerModel.swift
@@ -49,7 +49,7 @@ public class RulePickerModel: ObservableObject, Runnable {
                     return (rules, filter)
                 }
                 let filteredRules = rules.filter { item in
-                    [item.rootUrl.displayName, item.name].joined(separator: " ").localizedSearchMatches(string: filter)
+                    [item.archiveURL.displayName, item.name].joined(separator: " ").localizedSearchMatches(string: filter)
                 }
                 return (filteredRules, filter)
             }

--- a/core/Sources/FileawayCore/Model/RulesModel.swift
+++ b/core/Sources/FileawayCore/Model/RulesModel.swift
@@ -148,31 +148,3 @@ public class RulesModel: ObservableObject {
     }
     
 }
-
-extension Rule {
-
-    public init(_ ruleModel: RuleModel) {
-        self.init(id: ruleModel.id,
-                  name: ruleModel.name,
-                  variables: ruleModel.variables,
-                  destination: ruleModel.destination.map { Component($0) })
-    }
-
-}
-
-extension RuleList {
-
-    init(ruleModels: [RuleModel]) {
-        rules = ruleModels
-            .map { Rule($0) }
-    }
-
-    func models(for rootUrl: URL) -> [RuleModel] {
-        return rules
-            .map { rule in
-                return RuleModel(rootUrl: rootUrl, rule: rule)
-            }
-            .sorted { $0.name < $1.name }
-    }
-
-}

--- a/core/Sources/FileawayCore/Model/RulesModel.swift
+++ b/core/Sources/FileawayCore/Model/RulesModel.swift
@@ -23,19 +23,19 @@ import SwiftUI
 
 public class RulesModel: ObservableObject {
 
-    private let rootUrl: URL
-    private let url: URL
+    private let archiveURL: URL
+    private let fileURL: URL
 
     @Published public var ruleModels: [RuleModel]
 
     var rulesSubscription: Cancellable?
 
     public init(archiveURL: URL) {
-        self.rootUrl = archiveURL
-        self.url = archiveURL.rulesUrl
-        if FileManager.default.fileExists(atPath: self.url.path) {
+        self.archiveURL = archiveURL
+        self.fileURL = archiveURL.rulesUrl
+        if FileManager.default.fileExists(atPath: self.fileURL.path) {
             do {
-                self.ruleModels = try RuleList(url: self.url).models(for: self.rootUrl)
+                self.ruleModels = try RuleList(url: self.fileURL).models(for: self.archiveURL)
             } catch {
                 // TODO: Propagate this error!
                 print("Failed to load rules with error \(error).")
@@ -94,7 +94,7 @@ public class RulesModel: ObservableObject {
     public func new() throws -> RuleModel {
         let name = uniqueRuleName(preferredName: "Rule")
         let rule = RuleModel(id: UUID(),
-                             rootUrl: rootUrl,
+                             rootUrl: archiveURL,
                              name: name,
                              variables: [VariableModel(name: "Date", type: .date(hasDay: true))],
                              destination: [
@@ -144,7 +144,7 @@ public class RulesModel: ObservableObject {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(configurationList)
-        try data.write(to: url)
+        try data.write(to: fileURL)
     }
     
 }

--- a/core/Tests/FileawayCoreTests/RulesModelTests.swift
+++ b/core/Tests/FileawayCoreTests/RulesModelTests.swift
@@ -62,7 +62,7 @@ class RulesModelTests: XCTestCase {
         XCTAssert(rules.ruleModels.isEmpty)
 
         let rule = try rules.new()
-        XCTAssertEqual(rule.rootUrl, archiveURL)
+        XCTAssertEqual(rule.archiveURL, archiveURL)
         XCTAssertEqual(rule.name, "Rule")
         XCTAssertEqual(rules.ruleModels.count, 1)
     }
@@ -81,7 +81,7 @@ class RulesModelTests: XCTestCase {
         }
 
         XCTAssertNotEqual(rule2.id, rule1.id)
-        XCTAssertEqual(rule2.rootUrl, rule1.rootUrl)
+        XCTAssertEqual(rule2.archiveURL, rule1.archiveURL)
         XCTAssertEqual(rule2.name, "Copy of Rule")
         XCTAssertEqual(rule2.variables, rule1.variables)
         XCTAssertEqual(rule2.destination, rule1.destination)

--- a/ios/Fileaway/Views/Wizard/RulePickerRow.swift
+++ b/ios/Fileaway/Views/Wizard/RulePickerRow.swift
@@ -41,7 +41,7 @@ struct RulePickerRow: View {
             VStack {
                 Text(ruleModel.name)
                     .horizontalSpace(.trailing)
-                Text(ruleModel.rootUrl.displayName)
+                Text(ruleModel.archiveURL.displayName)
                     .foregroundColor(.secondary)
                     .horizontalSpace(.trailing)
             }

--- a/macos/Fileaway/Views/Settings/ComponentView.swift
+++ b/macos/Fileaway/Views/Settings/ComponentView.swift
@@ -39,16 +39,16 @@ struct SetFolderButton: View {
             openPanel.canChooseDirectories = true
             openPanel.canCreateDirectories = true
             var isDirectory = ObjCBool(true)
-            let currentDirectory = ruleModel.rootUrl.appendingPathComponent(componentModel.value)
+            let currentDirectory = ruleModel.archiveURL.appendingPathComponent(componentModel.value)
             if FileManager.default.fileExists(atPath: currentDirectory.path,
                                               isDirectory: &isDirectory) && isDirectory.boolValue {
                 openPanel.directoryURL = currentDirectory
             } else {
-                openPanel.directoryURL = ruleModel.rootUrl
+                openPanel.directoryURL = ruleModel.archiveURL
             }
             guard openPanel.runModal() == NSApplication.ModalResponse.OK,
                   let url = openPanel.url,
-                  let relativePath = url.relativePath(from: ruleModel.rootUrl) else {
+                  let relativePath = url.relativePath(from: ruleModel.archiveURL) else {
                 return
             }
             componentModel.value = relativePath + "/"

--- a/macos/Fileaway/Views/Wizard/RulePickerRow.swift
+++ b/macos/Fileaway/Views/Wizard/RulePickerRow.swift
@@ -39,7 +39,7 @@ struct RulePickerRow: View {
         HStack {
             VStack(alignment: .leading) {
                 Text(ruleModel.name)
-                Text(ruleModel.rootUrl.displayName)
+                Text(ruleModel.archiveURL.displayName)
                     .foregroundColor(.secondary)
             }
             Spacer()


### PR DESCRIPTION
This change makes the URL names more explicit in an attempt to avoid confusion between the URL of the archive, and the URL of the rules file within the archive.