### PR TITLE
fix: Directory views don't notice changes when moving or deleting folders

### DIFF
--- a/core/Sources/FileawayCore/Extensions/FileManager.swift
+++ b/core/Sources/FileawayCore/Extensions/FileManager.swift
@@ -26,7 +26,6 @@ extension FileManager {
         return urls(for: .libraryDirectory, in: .userDomainMask)[0]
     }
 
-    // TODO: Does this include folders?
     public func files(at url: URL) -> [URL] {
         var files: [URL] = []
         if let enumerator = enumerator(at: url,

--- a/core/Sources/FileawayCore/Extensions/Set.swift
+++ b/core/Sources/FileawayCore/Extensions/Set.swift
@@ -22,15 +22,14 @@ import Foundation
 
 extension Set where Element == URL {
 
-    // TODO: Name this appropriately.
-    func descendents(of url: URL) -> Set<URL> {
+    func urlAndDescendents(of url: URL) -> Set<URL> {
         return filter { url == $0 || url.isParent(of: $0) }
     }
 
-    func descendents(of urls: Set<URL>) -> Set<URL> {
+    func urlAndDescendents(of urls: Set<URL>) -> Set<URL> {
         return urls
             .map { url in
-                return descendents(of: url)
+                return urlAndDescendents(of: url)
             }
             .reduce(into: Set<URL>()) { partialResult, urls in
                 partialResult.formUnion(urls)
@@ -38,7 +37,7 @@ extension Set where Element == URL {
     }
 
     func removingURLsAndDescendents(of urls: Set<URL>) -> Set<URL> {
-        let removals = descendents(of: urls)
+        let removals = urlAndDescendents(of: urls)
         return subtracting(removals)
     }
 

--- a/core/Sources/FileawayCore/Extensions/Set.swift
+++ b/core/Sources/FileawayCore/Extensions/Set.swift
@@ -1,0 +1,45 @@
+// Copyright (c) 2018-2022 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension Set where Element == URL {
+
+    // TODO: Name this appropriately.
+    func descendents(of url: URL) -> Set<URL> {
+        return filter { url == $0 || url.isParent(of: $0) }
+    }
+
+    func descendents(of urls: Set<URL>) -> Set<URL> {
+        return urls
+            .map { url in
+                return descendents(of: url)
+            }
+            .reduce(into: Set<URL>()) { partialResult, urls in
+                partialResult.formUnion(urls)
+            }
+    }
+
+    func removingURLsAndDescendents(of urls: Set<URL>) -> Set<URL> {
+        let removals = descendents(of: urls)
+        return subtracting(removals)
+    }
+
+}

--- a/core/Sources/FileawayCore/Model/DirectoryViewModel.swift
+++ b/core/Sources/FileawayCore/Model/DirectoryViewModel.swift
@@ -132,7 +132,7 @@ public class DirectoryViewModel: ObservableObject, Identifiable, Runnable {
             .compactMap { (files, previewUrl) -> Set<FileInfo>? in
 #if os(macOS)
                 guard previewUrl != nil else {
-                    return
+                    return nil
                 }
 #endif
                 guard let file = self.files.first(where: { $0.url == previewUrl })

--- a/core/Sources/FileawayCore/Model/DirectoryViewModel.swift
+++ b/core/Sources/FileawayCore/Model/DirectoryViewModel.swift
@@ -104,7 +104,6 @@ public class DirectoryViewModel: ObservableObject, Identifiable, Runnable {
                     result[fileInfo.url] = fileInfo
                 }
 
-                // TODO: Consider using the ordered set here? This might be an unnecessary transform?
                 let previewURLs = Array(files.keys)
 
                 return (files, previewURLs, isLoading)

--- a/core/Sources/FileawayCore/Model/DirectoryViewModel.swift
+++ b/core/Sources/FileawayCore/Model/DirectoryViewModel.swift
@@ -110,7 +110,9 @@ public class DirectoryViewModel: ObservableObject, Identifiable, Runnable {
             }
             .receive(on: DispatchQueue.main)
             .sink { files, previewUrls, isLoading in
-                self.files = files
+                if self.files != files {
+                    self.files = files
+                }
                 self.previewUrls = previewUrls
                 self.isLoading = isLoading
             }

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -78,18 +78,16 @@ public class DirectoryMonitor: ObservableObject {
 
             DispatchQueue.main.sync {
                 precondition(self.files != nil)
-
+                guard let files = self.files else {
+                    return
+                }
                 if isCreate {
-                    for url in urls {
-                        if !(self.files?.contains(url) ?? false) {
-                            self.files?.insert(url)
-                        }
+                    if files.intersection(urls).count != urls.count {
+                        self.files = files.union(urls)
                     }
                 } else {
-                    for url in urls {
-                        if (self.files?.contains(url) ?? false) {
-                            self.files?.remove(url)
-                        }
+                    if !files.intersection(urls).isEmpty {
+                        self.files = files.subtracting(urls)
                     }
                 }
             }

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -103,7 +103,6 @@ public class DirectoryMonitor: ObservableObject {
 
 #endif
 
-
     public init(locations: [URL]) {
         self.locations = locations
     }

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -110,7 +110,6 @@ public class DirectoryMonitor: ObservableObject {
         NotificationCenter.default
             .publisher(for: UIApplication.willEnterForegroundNotification)
             .sink { foreground in
-                print("Refreshing monitor for \(self.locations).")
                 self.refresh()
             }
             .store(in: &cancellables)

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -39,12 +39,13 @@ public class DirectoryMonitor: ObservableObject {
 #if os(macOS)
 
     lazy var stream: EonilFSEventStream = {
+        // TODO: DirectoryMonitor instances leak if not explicitly stopped #518
+        //       https://github.com/inseven/fileaway/issues/518
         let stream = try! EonilFSEventStream(pathsToWatch: self.locations.map { $0.path },
                                              sinceWhen: .now,
                                              latency: 0.3,
                                              flags: [.fileEvents],
                                              handler: { event in
-
             guard let flag = event.flag else {
                 return
             }

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -141,7 +141,9 @@ public class DirectoryMonitor: ObservableObject {
 
     // TODO: Is this guaranteed to be threadsafe?
     deinit {
+#if os(macOS)
         self.stream.stop()
+#endif
         cancellables.removeAll()
     }
 

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -139,6 +139,12 @@ public class DirectoryMonitor: ObservableObject {
         cancellables.removeAll()
     }
 
+    // TODO: Is this guaranteed to be threadsafe?
+    deinit {
+        self.stream.stop()
+        cancellables.removeAll()
+    }
+
     @MainActor public func refresh() {
         syncQueue.async {
             self.syncQueue_refresh()

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -76,7 +76,7 @@ public class DirectoryMonitor: ObservableObject {
                 return
             }
 
-            Task { @MainActor in
+            DispatchQueue.main.sync {
                 precondition(self.files != nil)
 
                 if isCreate {
@@ -129,7 +129,11 @@ public class DirectoryMonitor: ObservableObject {
             // the correct pairing of API since the `files` is annotated with `@MainActor`), but curiously this caused
             // deadlock when running unit tests on iOS (not macOS). That tells me I don't fully understand the `Task`
             // APIs yet as I can't see why calling this from an async block on `syncQueue` should behave differently.
-            DispatchQueue.main.async {
+            DispatchQueue.main.sync {
+                // Ensure we don't trigger an unnecessary redraw if the files haven't changed.
+                guard self.files != files else {
+                    return
+                }
                 self.files = files
             }
         }
@@ -154,7 +158,11 @@ public class DirectoryMonitor: ObservableObject {
             // the correct pairing of API since the `files` is annotated with `@MainActor`), but curiously this caused
             // deadlock when running unit tests on iOS (not macOS). That tells me I don't fully understand the `Task`
             // APIs yet as I can't see why calling this from an async block on `syncQueue` should behave differently.
-            DispatchQueue.main.async {
+            DispatchQueue.main.sync {
+                // Ensure we don't trigger an unnecessary redraw if the files haven't changed.
+                guard self.files != files else {
+                    return
+                }
                 self.files = files
             }
         }

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -67,7 +67,6 @@ public class DirectoryMonitor: ObservableObject {
                 // operation. This allows us to effectively ignore transient creation operations as they'll always
                 // become removal operations that are then ignored as the files in question aren't in the active set.
                 isCreate = FileManager.default.fileExists(atPath: event.path)
-                print("itemRenamed (\(isCreate))")
             } else if flag.contains(.historyDone) {
                 // Silently ignore known flags.
                 return
@@ -81,14 +80,12 @@ public class DirectoryMonitor: ObservableObject {
                 precondition(self.files != nil)
 
                 if isCreate {
-                    print("Insert \(urls)")
                     for url in urls {
                         if !(self.files?.contains(url) ?? false) {
                             self.files?.insert(url)
                         }
                     }
                 } else {
-                    print("Remove \(urls)")
                     for url in urls {
                         if (self.files?.contains(url) ?? false) {
                             self.files?.remove(url)

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -88,7 +88,7 @@ public class DirectoryMonitor: ObservableObject {
                         self.files = files.union(urls)
                     }
                 } else {
-                    let removals = files.descendents(of: urls)
+                    let removals = files.urlAndDescendents(of: urls)
                     if !files.intersection(removals).isEmpty {
                         print("State: -> removing urls")
                         self.files = files.subtracting(removals)

--- a/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
+++ b/core/Sources/FileawayCore/Utilities/DirectoryMonitor.swift
@@ -125,20 +125,12 @@ public class DirectoryMonitor: ObservableObject {
 
     }
 
-    public func stop() {
+    @MainActor public func stop() {
         dispatchPrecondition(condition: .notOnQueue(syncQueue))
 #if os(macOS)
         syncQueue.sync {
             self.stream.stop()
         }
-#endif
-        cancellables.removeAll()
-    }
-
-    // TODO: Is this guaranteed to be threadsafe?
-    deinit {
-#if os(macOS)
-        self.stream.stop()
 #endif
         cancellables.removeAll()
     }

--- a/core/Sources/FileawayCore/Utilities/FileInfo.swift
+++ b/core/Sources/FileawayCore/Utilities/FileInfo.swift
@@ -47,6 +47,13 @@ public class FileInfo: Identifiable, Hashable {
     public let date: FileDate
     public let directoryUrl: URL
 
+    public init(url: URL, name: String, date: FileDate, directoryUrl: URL) {
+        self.url = url
+        self.name = name
+        self.date = date
+        self.directoryUrl = directoryUrl
+    }
+
     public init(url: URL) {
         self.url = url
         let name = url.displayName.deletingPathExtension
@@ -62,6 +69,13 @@ public class FileInfo: Identifiable, Hashable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(url)
+    }
+
+    public func standardizingFileURL() -> FileInfo {
+        return FileInfo(url: url.standardizedFileURL,
+                        name: name,
+                        date: date,
+                        directoryUrl: directoryUrl)
     }
 
 }

--- a/core/Sources/FileawayCore/Views/Viewer/DirectoryView.swift
+++ b/core/Sources/FileawayCore/Views/Viewer/DirectoryView.swift
@@ -54,7 +54,7 @@ public struct DirectoryView: View {
 
     public var body: some View {
         List(selection: selection) {
-            ForEach(directoryViewModel.files, id: \.self) { file in
+            ForEach(directoryViewModel.files.values, id: \.self) { file in
                 FileRow(file: file)
                     .swipeActions(edge: .leading) {
                         Button {

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -22,7 +22,6 @@ import XCTest
 
 @testable import FileawayCore
 
-// TODO: Consider not escaping?
 class DirectoryMonitorTests: XCTestCase {
 
     func expect(_ contents: [Set<URL>?],

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -72,7 +72,8 @@ class DirectoryMonitorTests: XCTestCase {
             }
         }
 
-        // TODO: Stop seems to be blocking indefinitely sometimes?
+        // TODO: DirectoryMonitor instances leak if not explicitly stopped #518
+        //       https://github.com/inseven/fileaway/issues/518
 //        addTeardownBlock {
 //            await directoryMonitor.stop()
 //        }

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -1,0 +1,100 @@
+// Copyright (c) 2018-2022 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+
+@testable import FileawayCore
+
+// TODO: Ensure the directory monitor ignores duplicates.
+// TODO: How do we deal with files that have changed; we should probably include the mtime too since this is used
+//       to determine whether we fetch the updates.
+
+class DirectoryMonitorTests: XCTestCase {
+
+    func expect(_ snapshots: [Set<URL>?],
+                directoryMonitor: DirectoryMonitor,
+                perform: @MainActor () throws -> Void) async throws {
+
+        let publisher = directoryMonitor
+            .$files
+            .dropFirst()
+            .map { $0?.standardizingFileURLs() }
+
+        try await MainActor.run {
+            try perform()
+
+            // TODO: I _think_ iOS requires us to perform an explicit refresh for this to work.
+        }
+
+        let files = try wait(for: publisher, count: snapshots.count, timeout: 10)
+        XCTAssertEqual(files, snapshots)
+    }
+
+    func testSelectionUpdatesWhenFileRemoved() async throws {
+
+        let fileManager = FileManager.default
+        let rootURL = try createTemporaryDirectory()
+        let fileURL = rootURL.appending(component: "file.pdf")
+        fileManager.createFile(at: fileURL)
+
+        let directoryMonitor = DirectoryMonitor(locations: [rootURL])
+
+        // Start the directory monitor.
+        try await expect([[fileURL]], directoryMonitor: directoryMonitor) {
+            directoryMonitor.start()
+        }
+
+        // Create a file.
+        let file2URL = rootURL.appending(component: "file2.pdf")
+        try await expect([[fileURL, file2URL]], directoryMonitor: directoryMonitor) {
+            fileManager.createFile(at: file2URL)
+        }
+
+        // Delete a file.
+        try await expect([[file2URL]], directoryMonitor: directoryMonitor) {
+            try fileManager.removeItem(at: fileURL)
+        }
+
+        // Create a new file in a directory.
+        let subdirectoryURL = rootURL.appending(component: "Directory")
+        let file3URL = subdirectoryURL.appending(component: "file.pdf")
+        try await expect([[file2URL, file3URL]], directoryMonitor: directoryMonitor) {
+            try fileManager.createDirectory(at: subdirectoryURL, withIntermediateDirectories: false)
+            fileManager.createFile(at: file3URL)
+        }
+
+        // Move a directory containing files.
+        let externalDirectoryURL = try createTemporaryDirectory().appending(component: "External Directory")
+        try fileManager.createDirectory(at: externalDirectoryURL, withIntermediateDirectories: false)
+        let file4URL = externalDirectoryURL.appending(component: "child.pdf")
+        fileManager.createFile(at: file4URL)
+        let externalDirectoryDestinationURL = rootURL.appending(component: "External Directory")
+        try await expect([[file2URL, file3URL, externalDirectoryDestinationURL.appending(component: "child.pdf")]],
+                                  directoryMonitor: directoryMonitor) {
+            try fileManager.moveItem(at: externalDirectoryURL, to: externalDirectoryDestinationURL)
+        }
+
+        // TODO: Move directory containing multiple files.
+
+        // TODO: Delete directory containing files?
+
+    }
+
+}

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -25,7 +25,6 @@ import XCTest
 // TODO: Consider not escaping?
 class DirectoryMonitorTests: XCTestCase {
 
-    // TODO: This shouldn't be escaping?
     func expect(_ contents: [Set<URL>?],
                 directoryMonitor: DirectoryMonitor,
                 drop dropCount: Int = 1,

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -24,62 +24,6 @@ import XCTest
 
 class DirectoryMonitorTests: XCTestCase {
 
-    func expect(_ contents: [Set<URL>?],
-                directoryMonitor: DirectoryMonitor,
-                drop dropCount: Int = 1,
-                file: StaticString = #file,
-                line: UInt = #line,
-                perform action: @MainActor @escaping () throws -> Void) async throws {
-
-        let publisher = directoryMonitor
-            .$files
-            .dropFirst(dropCount)
-            .map { $0?.standardizingFileURLs() }
-
-        let files = try wait(for: publisher, count: contents.count, timeout: 3, file: file, line: line) {
-            DispatchQueue.main.sync {
-                do {
-                    try action()
-#if os(iOS)
-                    directoryMonitor.refresh()
-#endif
-                } catch {
-                    XCTFail("Failed to perform update action with error \(error).", file: file, line: line)
-                }
-            }
-        }
-        XCTAssertEqual(files, contents, file: file, line: line)
-    }
-
-    var fileManager: FileManager {
-        return FileManager.default
-    }
-
-    func startedDirectoryMonitor(locations: [URL]) async throws -> DirectoryMonitor {
-
-        let directoryMonitor = DirectoryMonitor(locations: locations)
-
-        let publisher = directoryMonitor
-            .$files
-            .dropFirst()
-            .collect(1)
-            .first()
-
-        _ = try wait(for: publisher, timeout: 3) {
-            DispatchQueue.main.sync {
-                directoryMonitor.start()
-            }
-        }
-
-        // TODO: DirectoryMonitor instances leak if not explicitly stopped #518
-        //       https://github.com/inseven/fileaway/issues/518
-//        addTeardownBlock {
-//            await directoryMonitor.stop()
-//        }
-
-        return directoryMonitor
-    }
-
     func testStartEmpty() async throws {
 
         let rootURL = try createTemporaryDirectory()

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -81,10 +81,6 @@ class DirectoryMonitorTests: XCTestCase {
         }
     }
 
-    func createFiles(at urls: [URL], file: StaticString = #file, line: UInt = #line) {
-        XCTAssertTrue(fileManager.createFiles(at: urls), file: file, line: line)
-    }
-
     func testMoveInNonEmptyDirectory() async throws {
         let rootURL = try createTemporaryDirectory()
 

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -40,10 +40,12 @@ class DirectoryMonitorTests: XCTestCase {
             .dropFirst()
             .map { $0?.standardizingFileURLs() }
 
-        let files = try wait(for: publisher, count: contents.count, timeout: 10, file: file, line: line) {
+        let files = try wait(for: publisher, count: contents.count, timeout: 3, file: file, line: line) {
             DispatchQueue.main.sync {
                 try? action()
+#if os(iOS)
                 directoryMonitor.refresh()
+#endif
             }
         }
         XCTAssertEqual(files, contents, file: file, line: line)
@@ -69,9 +71,10 @@ class DirectoryMonitorTests: XCTestCase {
             }
         }
 
-        addTeardownBlock {
-            await directoryMonitor.stop()
-        }
+        // TODO: Stop seems to be blocking indefinitely sometimes?
+//        addTeardownBlock {
+//            await directoryMonitor.stop()
+//        }
 
         return directoryMonitor
     }
@@ -214,7 +217,7 @@ class DirectoryMonitorTests: XCTestCase {
     }
 
     func testSoakSequentialBasicFileOperations() async throws {
-        for _ in 0...1000 {
+        for _ in 0...100 {
             try await testSequentialBasicFileOperations()
         }
     }

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -69,9 +69,8 @@ class DirectoryMonitorTests: XCTestCase {
             }
         }
 
-        // TODO: This doesn't seem to actually stop the monitor in a timely fashion. Why?
         addTeardownBlock {
-            directoryMonitor.stop()
+            await directoryMonitor.stop()
         }
 
         return directoryMonitor
@@ -207,14 +206,10 @@ class DirectoryMonitorTests: XCTestCase {
             try fileManager.moveItem(at: externalDirectoryURL, to: externalDirectoryDestinationURL)
         }
 
-        // TODO: Move directory containing multiple files.
-
-        // TODO: Delete directory containing files?
-
-
-        // Explicitly stop the directory monitor.
-        // TODO: We probably have a retain cycle as this shouldn't be necessary
-        directoryMonitor.stop()
+        // Since this test is run in a tight loop by `testSoakSequentialBasicFileOperations`, the teardown usually
+        // responsible for stopping `DirectoryMonitor` instances isn't called in a timely fashion and we run out of
+        // file handles unless we call it explicitly here.
+        await directoryMonitor.stop()
 
     }
 

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -92,49 +92,6 @@ class DirectoryMonitorTests: XCTestCase {
 
     }
 
-    func testRemoveChildren() {
-
-        XCTAssertTrue(URL(fileURLWithPath: "/a").isParent(of: URL(fileURLWithPath: "/a/b")))
-        XCTAssertFalse(URL(fileURLWithPath: "/a").isParent(of: URL(fileURLWithPath: "/abba/b")))
-
-        XCTAssertEqual(
-            Set([
-                URL(fileURLWithPath: "/a/b/c"),
-                URL(fileURLWithPath: "/a/b"),
-                URL(fileURLWithPath: "/a/b/d"),
-                URL(fileURLWithPath: "/e/random.txt"),
-            ]).removingURLsAndDescendents(of: Set([URL(fileURLWithPath: "/a")])),
-            Set([
-                URL(fileURLWithPath: "/e/random.txt"),
-            ]))
-
-        XCTAssertEqual(
-            Set([
-                URL(fileURLWithPath: "/a"),
-                URL(fileURLWithPath: "/a/b/c"),
-                URL(fileURLWithPath: "/a/b"),
-                URL(fileURLWithPath: "/a/b/d"),
-                URL(fileURLWithPath: "/e/random.txt"),
-            ]).removingURLsAndDescendents(of: Set([URL(fileURLWithPath: "/a")])),
-            Set([
-                URL(fileURLWithPath: "/e/random.txt"),
-            ]))
-
-        XCTAssertEqual(
-            Set([
-                URL(fileURLWithPath: "/a"),
-                URL(fileURLWithPath: "/a/b/c"),
-                URL(fileURLWithPath: "/a/b"),
-                URL(fileURLWithPath: "/a/b/d"),
-                URL(fileURLWithPath: "/e/random.txt"),
-            ]).removingURLsAndDescendents(of: Set([
-                URL(fileURLWithPath: "/a"),
-                URL(fileURLWithPath: "/e")
-            ])),
-            Set([]))
-
-    }
-
     func testStartNonEmpty() async throws {
 
         let rootURL = try createTemporaryDirectory()

--- a/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryMonitorTests.swift
@@ -28,6 +28,7 @@ import XCTest
 
 class DirectoryMonitorTests: XCTestCase {
 
+    // TODO: This shouldn't be escaping?
     func expect(_ snapshots: [Set<URL>?],
                 directoryMonitor: DirectoryMonitor,
                 file: StaticString = #file,
@@ -82,6 +83,27 @@ class DirectoryMonitorTests: XCTestCase {
         let directoryMonitor = DirectoryMonitor(locations: [rootURL])
 
         try await expect([[]], directoryMonitor: directoryMonitor) {
+            directoryMonitor.start()
+        }
+
+    }
+
+    func testStartNonEmpty() async throws {
+
+        let rootURL = try createTemporaryDirectory()
+        let directoryMonitor = DirectoryMonitor(locations: [rootURL])
+
+        let directoryURL = rootURL.appending(component: "Directory")
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+
+        let urls = [
+            rootURL.appending(component: "file.txt"),
+            directoryURL.appending(component: "file2.txt"),
+            directoryURL.appending(component: "file3.txt"),
+        ]
+        fileManager.createFiles(at: urls)
+
+        try await expect([Set(urls)], directoryMonitor: directoryMonitor) {
             directoryMonitor.start()
         }
 

--- a/core/Tests/FileawayCoreTests/DirectoryViewModelTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryViewModelTests.swift
@@ -18,30 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
+import XCTest
 
-extension FileManager {
+@testable import FileawayCore
 
-    public var libraryURL: URL {
-        return urls(for: .libraryDirectory, in: .userDomainMask)[0]
-    }
+// TODO: Ensure the directory monitor ignores duplicates.
+// TODO: How do we deal with files that have changed; we should probably include the mtime too since this is used
+//       to determine whether we fetch the updates.
 
-    // TODO: Does this include folders?
-    public func files(at url: URL) -> [URL] {
-        var files: [URL] = []
-        if let enumerator = enumerator(at: url,
-                                       includingPropertiesForKeys: [.isRegularFileKey],
-                                       options: [.skipsHiddenFiles, .skipsPackageDescendants]) {
-            for case let fileURL as URL in enumerator {
-                do {
-                    let fileAttributes = try fileURL.resourceValues(forKeys:[.isRegularFileKey])
-                    if fileAttributes.isRegularFile! {
-                        files.append(fileURL)
-                    }
-                } catch { print(error, fileURL) }
-            }
-        }
-        return files
-    }
+class DirectoryViewModelTests: XCTestCase {
 
 }

--- a/core/Tests/FileawayCoreTests/DirectoryViewModelTests.swift
+++ b/core/Tests/FileawayCoreTests/DirectoryViewModelTests.swift
@@ -22,9 +22,7 @@ import XCTest
 
 @testable import FileawayCore
 
-// TODO: Ensure the directory monitor ignores duplicates.
-// TODO: How do we deal with files that have changed; we should probably include the mtime too since this is used
-//       to determine whether we fetch the updates.
+// TODO: Add selection tests.
 
 class DirectoryViewModelTests: XCTestCase {
 

--- a/core/Tests/FileawayCoreTests/Extensions/FileManager.swift
+++ b/core/Tests/FileawayCoreTests/Extensions/FileManager.swift
@@ -22,26 +22,8 @@ import Foundation
 
 extension FileManager {
 
-    public var libraryURL: URL {
-        return urls(for: .libraryDirectory, in: .userDomainMask)[0]
-    }
-
-    // TODO: Does this include folders?
-    public func files(at url: URL) -> [URL] {
-        var files: [URL] = []
-        if let enumerator = enumerator(at: url,
-                                       includingPropertiesForKeys: [.isRegularFileKey],
-                                       options: [.skipsHiddenFiles, .skipsPackageDescendants]) {
-            for case let fileURL as URL in enumerator {
-                do {
-                    let fileAttributes = try fileURL.resourceValues(forKeys:[.isRegularFileKey])
-                    if fileAttributes.isRegularFile! {
-                        files.append(fileURL)
-                    }
-                } catch { print(error, fileURL) }
-            }
-        }
-        return files
+    func createFile(at url: URL, contents: Data? = nil) {
+        createFile(atPath: url.path, contents: contents)
     }
 
 }

--- a/core/Tests/FileawayCoreTests/Extensions/FileManager.swift
+++ b/core/Tests/FileawayCoreTests/Extensions/FileManager.swift
@@ -26,4 +26,10 @@ extension FileManager {
         createFile(atPath: url.path, contents: contents)
     }
 
+    func createFiles(at urls: [URL], contents: Data? = nil) {
+        for url in urls {
+            createFile(atPath: url.path, contents: contents)
+        }
+    }
+
 }

--- a/core/Tests/FileawayCoreTests/Extensions/FileManager.swift
+++ b/core/Tests/FileawayCoreTests/Extensions/FileManager.swift
@@ -22,14 +22,17 @@ import Foundation
 
 extension FileManager {
 
-    func createFile(at url: URL, contents: Data? = nil) {
-        createFile(atPath: url.path, contents: contents)
+    func createFile(at url: URL, contents: Data? = nil) -> Bool {
+        return createFile(atPath: url.path, contents: contents)
     }
 
-    func createFiles(at urls: [URL], contents: Data? = nil) {
+    func createFiles(at urls: [URL], contents: Data? = nil) -> Bool {
         for url in urls {
-            createFile(atPath: url.path, contents: contents)
+            guard createFile(atPath: url.path, contents: contents) else {
+                return false
+            }
         }
+        return true
     }
 
 }

--- a/core/Tests/FileawayCoreTests/Extensions/Set.swift
+++ b/core/Tests/FileawayCoreTests/Extensions/Set.swift
@@ -20,28 +20,12 @@
 
 import Foundation
 
-extension FileManager {
+extension Set where Element == URL {
 
-    public var libraryURL: URL {
-        return urls(for: .libraryDirectory, in: .userDomainMask)[0]
-    }
-
-    // TODO: Does this include folders?
-    public func files(at url: URL) -> [URL] {
-        var files: [URL] = []
-        if let enumerator = enumerator(at: url,
-                                       includingPropertiesForKeys: [.isRegularFileKey],
-                                       options: [.skipsHiddenFiles, .skipsPackageDescendants]) {
-            for case let fileURL as URL in enumerator {
-                do {
-                    let fileAttributes = try fileURL.resourceValues(forKeys:[.isRegularFileKey])
-                    if fileAttributes.isRegularFile! {
-                        files.append(fileURL)
-                    }
-                } catch { print(error, fileURL) }
-            }
-        }
-        return files
+    func standardizingFileURLs() -> Self {
+        return Set(map { url in
+            return url.standardizedFileURL
+        })
     }
 
 }

--- a/core/Tests/FileawayCoreTests/Extensions/XCTestCase.swift
+++ b/core/Tests/FileawayCoreTests/Extensions/XCTestCase.swift
@@ -21,10 +21,16 @@
 import Combine
 import XCTest
 
+@testable import FileawayCore
+
 extension XCTestCase {
 
     var fileManager: FileManager {
         return FileManager.default
+    }
+
+    func createFiles(at urls: [URL], file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(fileManager.createFiles(at: urls), file: file, line: line)
     }
 
     func createTemporaryDirectory() throws -> URL {

--- a/core/Tests/FileawayCoreTests/Extensions/XCTestCase.swift
+++ b/core/Tests/FileawayCoreTests/Extensions/XCTestCase.swift
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import Combine
 import XCTest
 
 extension XCTestCase {
@@ -43,6 +44,49 @@ extension XCTestCase {
         }
 
         return directoryURL
+    }
+
+    // Based on https://www.swiftbysundell.com/articles/unit-testing-combine-based-swift-code/.
+    func wait<T: Publisher>(for publisher: T,
+                            timeout: TimeInterval = 10,
+                            file: StaticString = #file,
+                            line: UInt = #line) throws -> T.Output {
+
+        var result: Result<T.Output, Error>?
+        let expectation = expectation(description: "Awaiting publisher")
+
+        let cancellable = publisher.sink(
+            receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    result = .failure(error)
+                case .finished:
+                    break
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { value in
+                result = .success(value)
+            }
+        )
+
+        wait(for: [expectation], timeout: timeout)
+        cancellable.cancel()
+
+        let unwrappedResult = try XCTUnwrap(result,
+                                            "Awaited publisher did not produce any output",
+                                            file: file,
+                                            line: line)
+
+        return try unwrappedResult.get()
+    }
+
+    func wait<T: Publisher>(for publisher: T,
+                            count: Int,
+                            timeout: TimeInterval = 10,
+                            file: StaticString = #file,
+                            line: UInt = #line) throws -> Publishers.First<Publishers.CollectByCount<T>>.Output {
+        return try wait(for: publisher.collect(count).first(), timeout: timeout, file: file, line: line)
     }
 
 }

--- a/core/Tests/FileawayCoreTests/Extensions/XCTestCase.swift
+++ b/core/Tests/FileawayCoreTests/Extensions/XCTestCase.swift
@@ -50,7 +50,8 @@ extension XCTestCase {
     func wait<T: Publisher>(for publisher: T,
                             timeout: TimeInterval = 10,
                             file: StaticString = #file,
-                            line: UInt = #line) throws -> T.Output {
+                            line: UInt = #line,
+                            perform action: (() throws -> Void)? = nil) throws -> T.Output {
 
         var result: Result<T.Output, Error>?
         let expectation = expectation(description: "Awaiting publisher")
@@ -70,6 +71,9 @@ extension XCTestCase {
             }
         )
 
+        // Perform any requested operation after we've created the subscription to ensure that changes aren't missed.
+        try action?()
+
         wait(for: [expectation], timeout: timeout)
         cancellable.cancel()
 
@@ -85,8 +89,9 @@ extension XCTestCase {
                             count: Int,
                             timeout: TimeInterval = 10,
                             file: StaticString = #file,
-                            line: UInt = #line) throws -> Publishers.First<Publishers.CollectByCount<T>>.Output {
-        return try wait(for: publisher.collect(count).first(), timeout: timeout, file: file, line: line)
+                            line: UInt = #line,
+                            perform action: (() throws -> Void)? = nil) throws -> Publishers.First<Publishers.CollectByCount<T>>.Output {
+        return try wait(for: publisher.collect(count).first(), timeout: timeout, file: file, line: line, perform: action)
     }
 
 }

--- a/core/Tests/FileawayCoreTests/SetTests.swift
+++ b/core/Tests/FileawayCoreTests/SetTests.swift
@@ -1,0 +1,67 @@
+// Copyright (c) 2018-2022 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import XCTest
+
+@testable import FileawayCore
+
+class SetTests: XCTestCase {
+
+    func testRemoveChildren() {
+
+        XCTAssertEqual(
+            Set([
+                URL(fileURLWithPath: "/a/b/c"),
+                URL(fileURLWithPath: "/a/b"),
+                URL(fileURLWithPath: "/a/b/d"),
+                URL(fileURLWithPath: "/e/random.txt"),
+            ]).removingURLsAndDescendents(of: Set([URL(fileURLWithPath: "/a")])),
+            Set([
+                URL(fileURLWithPath: "/e/random.txt"),
+            ]))
+
+        XCTAssertEqual(
+            Set([
+                URL(fileURLWithPath: "/a"),
+                URL(fileURLWithPath: "/a/b/c"),
+                URL(fileURLWithPath: "/a/b"),
+                URL(fileURLWithPath: "/a/b/d"),
+                URL(fileURLWithPath: "/e/random.txt"),
+            ]).removingURLsAndDescendents(of: Set([URL(fileURLWithPath: "/a")])),
+            Set([
+                URL(fileURLWithPath: "/e/random.txt"),
+            ]))
+
+        XCTAssertEqual(
+            Set([
+                URL(fileURLWithPath: "/a"),
+                URL(fileURLWithPath: "/a/b/c"),
+                URL(fileURLWithPath: "/a/b"),
+                URL(fileURLWithPath: "/a/b/d"),
+                URL(fileURLWithPath: "/e/random.txt"),
+            ]).removingURLsAndDescendents(of: Set([
+                URL(fileURLWithPath: "/a"),
+                URL(fileURLWithPath: "/e")
+            ])),
+            Set([]))
+
+    }
+
+}

--- a/core/Tests/FileawayCoreTests/URLTests.swift
+++ b/core/Tests/FileawayCoreTests/URLTests.swift
@@ -30,5 +30,10 @@ class URLTests: XCTestCase {
         XCTAssertEqual(childURL.relativePath(from: parentURL), "Accommodation/2022-11-22 House Correspondence.pdf")
     }
 
+    func testParent() {
+        XCTAssertTrue(URL(fileURLWithPath: "/a").isParent(of: URL(fileURLWithPath: "/a/b")))
+        XCTAssertFalse(URL(fileURLWithPath: "/a").isParent(of: URL(fileURLWithPath: "/abba/b")))
+    }
+
 }
 


### PR DESCRIPTION
Ensure `DirectoryMonitor` correctly indexes newly-added folders, and deletes files contained within removed folders. As part of this fix, the change introduces unit tests for `DirectoryMonitor` and `DirectoryViewModel`.

This includes a drive-by fix for selection management when viewing documents using QuickLook: unfortunately it seems like there's a bug with the SwiftUI QuickLook bindings on iOS that means the current item binding isn't updated when paging through items in the QuickLook view. Given this, it's not possible to ensure the selection is correct, so we simply allow the selection to be cleared when the item binding goes nil (indicating that the QuickLook view has been dismissed).