### PR TITLE
fix: Update the licenses

### DIFF
--- a/core/Sources/FileawayCore/Legal.swift
+++ b/core/Sources/FileawayCore/Legal.swift
@@ -22,6 +22,7 @@ import Foundation
 
 import Diligence
 import Interact
+import Glitter
 
 public struct Legal {
 
@@ -46,6 +47,7 @@ public struct Legal {
             Credit("Terrence Talbot")
         }
     } licenses: {
+        (.glitter)
         (.interact)
         License("DIFlowLayout", author: "Daniel Inoa", filename: "diflowlayout-license", bundle: .module)
         License("EonilFSEvents", author: "Hoon H., Eonil", filename: "eonilfsevents-license", bundle: .module)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,6 +21,8 @@ navigation:
 footer:
   - title: Privacy Policy
     href: /privacy-policy
+  - title: License
+    href: /license
   - title: More Software
     href: https://jbmorley.co.uk/software/
 

--- a/docs/license/index.md
+++ b/docs/license/index.md
@@ -1,12 +1,8 @@
-# Fileaway
+---
+title: License
+---
 
-[![Build](https://github.com/jbmorley/fileaway/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/jbmorley/fileaway/actions/workflows/build.yaml)
-
-Document management app for iOS and macOS.
-
-![macOS screenshot](screenshots/macos.png)
-
-## Licensing
+# License
 
 Fileaway is licensed under the MIT License (see [LICENSE](LICENSE)). It depends on the following separately licensed third-party libraries and components:
 


### PR DESCRIPTION
This change adds the Glitter and Sparkle licenses to the app, and lists licenses in the readme and website.
