### PR TITLE
refactor: Convert the iOS Xcode project to folders

### DIFF
--- a/ios/Fileaway-iOS.xcodeproj/project.pbxproj
+++ b/ios/Fileaway-iOS.xcodeproj/project.pbxproj
@@ -3,38 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		D81C5D93249BE3710083BD6F /* RulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81C5D92249BE3710083BD6F /* RulesView.swift */; };
-		D81C5D95249BE6F40083BD6F /* RuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81C5D94249BE6F40083BD6F /* RuleView.swift */; };
-		D85067FA292B8DE80017865A /* FileTypesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85067F9292B8DE80017865A /* FileTypesView.swift */; };
-		D850BD3329333E3800D81AAA /* DocumentPreviewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850BD3229333E3800D81AAA /* DocumentPreviewHeader.swift */; };
-		D850BD3629333FF300D81AAA /* CGSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850BD3529333FF300D81AAA /* CGSize.swift */; };
-		D85532A0291E5FB400C21E12 /* WizardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D855329F291E5FB400C21E12 /* WizardView.swift */; };
-		D864870D292CB99C007CD688 /* AddFileTypesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864870C292CB99C007CD688 /* AddFileTypesView.swift */; };
-		D8648710292CD08F007CD688 /* WizardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D864870F292CD08F007CD688 /* WizardModel.swift */; };
-		D8648712292D323A007CD688 /* RulePickerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8648711292D323A007CD688 /* RulePickerRow.swift */; };
 		D86AA556291DB7E00078B2DA /* FilePicker in Frameworks */ = {isa = PBXBuildFile; productRef = D86AA555291DB7E00078B2DA /* FilePicker */; };
 		D88B353D28B61247000C8910 /* FileawayCore in Frameworks */ = {isa = PBXBuildFile; productRef = D88B353C28B61247000C8910 /* FileawayCore */; };
-		D8A871D22916D56400B2932A /* ComponentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A871D12916D56400B2932A /* ComponentItem.swift */; };
 		D8A871D72917F82C00B2932A /* Interact in Frameworks */ = {isa = PBXBuildFile; productRef = D8A871D62917F82C00B2932A /* Interact */; };
-		D8C15DBA291A498F002DB14D /* FileawayApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C15DB9291A498F002DB14D /* FileawayApp.swift */; };
-		D8CAE3EE249D3AD70047CA36 /* ErrorText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CAE3ED249D3AD70047CA36 /* ErrorText.swift */; };
-		D8CCB80D2143672700AC445F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8CCB80C2143672700AC445F /* Assets.xcassets */; };
-		D8CCB8102143672700AC445F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D8CCB80E2143672700AC445F /* LaunchScreen.storyboard */; };
-		D8CCB81B2143672700AC445F /* FileawayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CCB81A2143672700AC445F /* FileawayTests.swift */; };
-		D8CCB8262143672700AC445F /* FileawayUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CCB8252143672700AC445F /* FileawayUITests.swift */; };
-		D8CCD293246EDC6A007EF2BB /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CCD292246EDC6A007EF2BB /* SettingsView.swift */; };
-		D8D81EB0291DC70200870E6E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D81EAF291DC70200870E6E /* ContentView.swift */; };
-		D8D81EB2291DD07800870E6E /* VariableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D81EB1291DD07800870E6E /* VariableView.swift */; };
-		D8D81EB9291DD23800870E6E /* VariableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D81EB8291DD23800870E6E /* VariableRow.swift */; };
-		D8E4CA5B249CF8A600F5BC8E /* Selectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E4CA5A249CF8A600F5BC8E /* Selectable.swift */; };
-		D8E4CA5D249D061D00F5BC8E /* EditableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E4CA5C249D061D00F5BC8E /* EditableText.swift */; };
-		D8F763DA292259960051D740 /* RulePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F763D9292259960051D740 /* RulePicker.swift */; };
-		D8F763DC29225F720051D740 /* RuleFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F763DB29225F720051D740 /* RuleFormView.swift */; };
-		D8F763DE29226FD30051D740 /* DocumentPreviewButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F763DD29226FD30051D740 /* DocumentPreviewButton.swift */; };
 		D8FB857F2916D2430024F885 /* Diligence in Frameworks */ = {isa = PBXBuildFile; productRef = D8FB857E2916D2430024F885 /* Diligence */; };
 /* End PBXBuildFile section */
 
@@ -56,41 +31,43 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		D81C5D92249BE3710083BD6F /* RulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulesView.swift; sourceTree = "<group>"; };
-		D81C5D94249BE6F40083BD6F /* RuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleView.swift; sourceTree = "<group>"; };
-		D85067F9292B8DE80017865A /* FileTypesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypesView.swift; sourceTree = "<group>"; };
-		D850BD3229333E3800D81AAA /* DocumentPreviewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPreviewHeader.swift; sourceTree = "<group>"; };
-		D850BD3529333FF300D81AAA /* CGSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGSize.swift; sourceTree = "<group>"; };
-		D855329F291E5FB400C21E12 /* WizardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WizardView.swift; sourceTree = "<group>"; };
-		D864870C292CB99C007CD688 /* AddFileTypesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFileTypesView.swift; sourceTree = "<group>"; };
-		D864870F292CD08F007CD688 /* WizardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WizardModel.swift; sourceTree = "<group>"; };
-		D8648711292D323A007CD688 /* RulePickerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulePickerRow.swift; sourceTree = "<group>"; };
 		D866D66326197AC80025329E /* FileawayCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FileawayCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86AA554291DB7BF0078B2DA /* FilePicker */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FilePicker; path = ../FilePicker; sourceTree = "<group>"; };
-		D8A871D12916D56400B2932A /* ComponentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentItem.swift; sourceTree = "<group>"; };
 		D8B0B3D425314771001EB2C2 /* Fileaway.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Fileaway.entitlements; sourceTree = "<group>"; };
-		D8C15DB9291A498F002DB14D /* FileawayApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileawayApp.swift; sourceTree = "<group>"; };
-		D8CAE3ED249D3AD70047CA36 /* ErrorText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorText.swift; sourceTree = "<group>"; };
 		D8CCB8022143672700AC445F /* Fileaway.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fileaway.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D8CCB80C2143672700AC445F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		D8CCB80F2143672700AC445F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		D8CCB8112143672700AC445F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D8CCB8162143672700AC445F /* FileawayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FileawayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D8CCB81A2143672700AC445F /* FileawayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileawayTests.swift; sourceTree = "<group>"; };
-		D8CCB81C2143672700AC445F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D8CCB8212143672700AC445F /* FileawayUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FileawayUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D8CCB8252143672700AC445F /* FileawayUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileawayUITests.swift; sourceTree = "<group>"; };
-		D8CCB8272143672700AC445F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D8CCD292246EDC6A007EF2BB /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		D8D81EAF291DC70200870E6E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		D8D81EB1291DD07800870E6E /* VariableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableView.swift; sourceTree = "<group>"; };
-		D8D81EB8291DD23800870E6E /* VariableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariableRow.swift; sourceTree = "<group>"; };
-		D8E4CA5A249CF8A600F5BC8E /* Selectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selectable.swift; sourceTree = "<group>"; };
-		D8E4CA5C249D061D00F5BC8E /* EditableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableText.swift; sourceTree = "<group>"; };
-		D8F763D9292259960051D740 /* RulePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulePicker.swift; sourceTree = "<group>"; };
-		D8F763DB29225F720051D740 /* RuleFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleFormView.swift; sourceTree = "<group>"; };
-		D8F763DD29226FD30051D740 /* DocumentPreviewButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPreviewButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		D840BD4D2E26F47200C8B23A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = D8CCB8012143672700AC445F /* Fileaway */;
+		};
+		D840BD522E26F47500C8B23A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				FileawayTests.swift,
+			);
+			target = D8CCB8152143672700AC445F /* FileawayTests */;
+		};
+		D840BD572E26F47700C8B23A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				FileawayUITests.swift,
+			);
+			target = D8CCB8202143672700AC445F /* FileawayUITests */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		D840BD342E26F47200C8B23A /* Fileaway */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D840BD4D2E26F47200C8B23A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Fileaway; sourceTree = "<group>"; };
+		D840BD502E26F47500C8B23A /* FileawayTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D840BD522E26F47500C8B23A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = FileawayTests; sourceTree = "<group>"; };
+		D840BD552E26F47700C8B23A /* FileawayUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D840BD572E26F47700C8B23A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = FileawayUITests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		D8CCB7FF2143672700AC445F /* Frameworks */ = {
@@ -121,34 +98,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		D81C5D8F249BDD3C0083BD6F /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				D8F763D8292255FE0051D740 /* Common */,
-				D8F763D42922553F0051D740 /* Editor */,
-				D8F763D6292255A30051D740 /* Settings */,
-				D8F763D3292255200051D740 /* Viewer */,
-				D8F763D5292255780051D740 /* Wizard */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
-		D850BD3429333FE600D81AAA /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				D850BD3529333FF300D81AAA /* CGSize.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		D864870E292CCF2D007CD688 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				D864870F292CD08F007CD688 /* WizardModel.swift */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
 		D86AA553291DB7BF0078B2DA /* Packages */ = {
 			isa = PBXGroup;
 			children = (
@@ -170,9 +119,9 @@
 			children = (
 				D86AA553291DB7BF0078B2DA /* Packages */,
 				D8B0B3D425314771001EB2C2 /* Fileaway.entitlements */,
-				D8CCB8042143672700AC445F /* Fileaway */,
-				D8CCB8192143672700AC445F /* FileawayTests */,
-				D8CCB8242143672700AC445F /* FileawayUITests */,
+				D840BD342E26F47200C8B23A /* Fileaway */,
+				D840BD502E26F47500C8B23A /* FileawayTests */,
+				D840BD552E26F47700C8B23A /* FileawayUITests */,
 				D8BCA522216F069B002A624D /* Frameworks */,
 				D8CCB8032143672700AC445F /* Products */,
 			);
@@ -186,91 +135,6 @@
 				D8CCB8212143672700AC445F /* FileawayUITests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		D8CCB8042143672700AC445F /* Fileaway */ = {
-			isa = PBXGroup;
-			children = (
-				D8CCB8112143672700AC445F /* Info.plist */,
-				D8C15DB9291A498F002DB14D /* FileawayApp.swift */,
-				D8CCB80C2143672700AC445F /* Assets.xcassets */,
-				D850BD3429333FE600D81AAA /* Extensions */,
-				D8CCB80E2143672700AC445F /* LaunchScreen.storyboard */,
-				D864870E292CCF2D007CD688 /* Model */,
-				D81C5D8F249BDD3C0083BD6F /* Views */,
-			);
-			path = Fileaway;
-			sourceTree = "<group>";
-		};
-		D8CCB8192143672700AC445F /* FileawayTests */ = {
-			isa = PBXGroup;
-			children = (
-				D8CCB81A2143672700AC445F /* FileawayTests.swift */,
-				D8CCB81C2143672700AC445F /* Info.plist */,
-			);
-			path = FileawayTests;
-			sourceTree = "<group>";
-		};
-		D8CCB8242143672700AC445F /* FileawayUITests */ = {
-			isa = PBXGroup;
-			children = (
-				D8CCB8252143672700AC445F /* FileawayUITests.swift */,
-				D8CCB8272143672700AC445F /* Info.plist */,
-			);
-			path = FileawayUITests;
-			sourceTree = "<group>";
-		};
-		D8F763D3292255200051D740 /* Viewer */ = {
-			isa = PBXGroup;
-			children = (
-				D8D81EAF291DC70200870E6E /* ContentView.swift */,
-			);
-			path = Viewer;
-			sourceTree = "<group>";
-		};
-		D8F763D42922553F0051D740 /* Editor */ = {
-			isa = PBXGroup;
-			children = (
-				D8A871D12916D56400B2932A /* ComponentItem.swift */,
-				D81C5D92249BE3710083BD6F /* RulesView.swift */,
-				D81C5D94249BE6F40083BD6F /* RuleView.swift */,
-				D8D81EB8291DD23800870E6E /* VariableRow.swift */,
-				D8D81EB1291DD07800870E6E /* VariableView.swift */,
-			);
-			path = Editor;
-			sourceTree = "<group>";
-		};
-		D8F763D5292255780051D740 /* Wizard */ = {
-			isa = PBXGroup;
-			children = (
-				D8F763DD29226FD30051D740 /* DocumentPreviewButton.swift */,
-				D850BD3229333E3800D81AAA /* DocumentPreviewHeader.swift */,
-				D8F763DB29225F720051D740 /* RuleFormView.swift */,
-				D8F763D9292259960051D740 /* RulePicker.swift */,
-				D8648711292D323A007CD688 /* RulePickerRow.swift */,
-				D855329F291E5FB400C21E12 /* WizardView.swift */,
-			);
-			path = Wizard;
-			sourceTree = "<group>";
-		};
-		D8F763D6292255A30051D740 /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				D864870C292CB99C007CD688 /* AddFileTypesView.swift */,
-				D85067F9292B8DE80017865A /* FileTypesView.swift */,
-				D8CCD292246EDC6A007EF2BB /* SettingsView.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
-		D8F763D8292255FE0051D740 /* Common */ = {
-			isa = PBXGroup;
-			children = (
-				D8E4CA5C249D061D00F5BC8E /* EditableText.swift */,
-				D8CAE3ED249D3AD70047CA36 /* ErrorText.swift */,
-				D8E4CA5A249CF8A600F5BC8E /* Selectable.swift */,
-			);
-			path = Common;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -287,6 +151,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D840BD342E26F47200C8B23A /* Fileaway */,
 			);
 			name = Fileaway;
 			packageProductDependencies = (
@@ -388,8 +255,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8CCB8102143672700AC445F /* LaunchScreen.storyboard in Resources */,
-				D8CCB80D2143672700AC445F /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -414,27 +279,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8D81EB2291DD07800870E6E /* VariableView.swift in Sources */,
-				D850BD3329333E3800D81AAA /* DocumentPreviewHeader.swift in Sources */,
-				D850BD3629333FF300D81AAA /* CGSize.swift in Sources */,
-				D85532A0291E5FB400C21E12 /* WizardView.swift in Sources */,
-				D8F763DE29226FD30051D740 /* DocumentPreviewButton.swift in Sources */,
-				D8A871D22916D56400B2932A /* ComponentItem.swift in Sources */,
-				D8F763DC29225F720051D740 /* RuleFormView.swift in Sources */,
-				D8D81EB0291DC70200870E6E /* ContentView.swift in Sources */,
-				D8648712292D323A007CD688 /* RulePickerRow.swift in Sources */,
-				D8C15DBA291A498F002DB14D /* FileawayApp.swift in Sources */,
-				D81C5D95249BE6F40083BD6F /* RuleView.swift in Sources */,
-				D8648710292CD08F007CD688 /* WizardModel.swift in Sources */,
-				D8E4CA5B249CF8A600F5BC8E /* Selectable.swift in Sources */,
-				D8CCD293246EDC6A007EF2BB /* SettingsView.swift in Sources */,
-				D8F763DA292259960051D740 /* RulePicker.swift in Sources */,
-				D85067FA292B8DE80017865A /* FileTypesView.swift in Sources */,
-				D8CAE3EE249D3AD70047CA36 /* ErrorText.swift in Sources */,
-				D81C5D93249BE3710083BD6F /* RulesView.swift in Sources */,
-				D8E4CA5D249D061D00F5BC8E /* EditableText.swift in Sources */,
-				D864870D292CB99C007CD688 /* AddFileTypesView.swift in Sources */,
-				D8D81EB9291DD23800870E6E /* VariableRow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -442,7 +286,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8CCB81B2143672700AC445F /* FileawayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -450,7 +293,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8CCB8262143672700AC445F /* FileawayUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -468,17 +310,6 @@
 			targetProxy = D8CCB8222143672700AC445F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
-
-/* Begin PBXVariantGroup section */
-		D8CCB80E2143672700AC445F /* LaunchScreen.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				D8CCB80F2143672700AC445F /* Base */,
-			);
-			name = LaunchScreen.storyboard;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		D8CCB8282143672700AC445F /* Debug */ = {
@@ -660,7 +491,6 @@
 		D8CCB82E2143672700AC445F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S4WXAUZQEV;
@@ -681,7 +511,6 @@
 		D8CCB82F2143672700AC445F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S4WXAUZQEV;
@@ -702,7 +531,6 @@
 		D8CCB8312143672700AC445F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S4WXAUZQEV;
 				INFOPLIST_FILE = FileawayUITests/Info.plist;
@@ -722,7 +550,6 @@
 		D8CCB8322143672700AC445F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S4WXAUZQEV;
 				INFOPLIST_FILE = FileawayUITests/Info.plist;


### PR DESCRIPTION
This will hopefully reduce the amount of project file churn in the future.
