### PR TITLE
refactor: Move `GCSize.navigationBarIcon` extension into FileawayCore

### DIFF
--- a/core/Sources/FileawayCore/Extensions/CGSize.swift
+++ b/core/Sources/FileawayCore/Extensions/CGSize.swift
@@ -22,6 +22,6 @@ import CoreGraphics
 
 extension CGSize {
 
-    static let navigationBarIcon = CGSize(width: 32.0, height: 32.0)
+    public static let navigationBarIcon = CGSize(width: 32.0, height: 32.0)
 
 }


### PR DESCRIPTION
Preparatory work for combining iOS and macOS projects.
