### PR TITLE
refactor: Rename the mac wizard view back to `WizardView`

### DIFF
--- a/macos/Fileaway/Scenes/Wizard.swift
+++ b/macos/Fileaway/Scenes/Wizard.swift
@@ -35,7 +35,7 @@ struct Wizard: Scene {
     var body: some Scene {
         WindowGroup(id: Self.windowID, for: URL.self) { $url in
             if let url = url {
-                PhoneWizardView(url: url)
+                WizardView(url: url)
                     .environmentObject(applicationModel)
             }
         }

--- a/macos/Fileaway/Views/Wizard/WizardView.swift
+++ b/macos/Fileaway/Views/Wizard/WizardView.swift
@@ -32,7 +32,7 @@ class RulesWizardModel: ObservableObject {
 
 }
 
-struct PhoneWizardView: View {
+struct WizardView: View {
 
     @EnvironmentObject private var applicationModel: ApplicationModel
 


### PR DESCRIPTION
This was renamed in error.
