### PR TITLE
fix: Unify macOS and iOS projects

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -145,11 +145,11 @@ popd
 # Build, test and archive the iOS project.
 sudo xcode-select --switch "$IOS_XCODE_PATH"
 xcode_project \
-    -scheme "Fileaway iOS" \
+    -scheme "Fileaway macOS" \
     -destination "$DEFAULT_IPHONE_DESTINATION" \
     clean build build-for-testing test
 xcode_project \
-    -scheme "Fileaway iOS" \
+    -scheme "Fileaway macOS" \
     -config Release \
     -archivePath "$IOS_ARCHIVE_PATH" \
     -destination "generic/platform=iOS" \


### PR DESCRIPTION
This change updates the project to build both macOS and iOS apps from the same Xcode project.
