### PR TITLE
fix: 🔎 Make empty search results clearer

### DIFF
--- a/apple/Fileaway/Views/Viewer/DirectoryView.swift
+++ b/apple/Fileaway/Views/Viewer/DirectoryView.swift
@@ -141,9 +141,15 @@ public struct DirectoryView: View {
                                            systemImage: "party.popper",
                                            description: Text("New files will appear here automatically."))
                 } else {
-                    ContentUnavailableView("No Results",
-                                           systemImage: "magnifyingglass",
-                                           description: Text("No files match '\(directoryViewModel.filter)'"))
+                    ContentUnavailableView {
+                        Label("No Results", systemImage: "magnifyingglass")
+                    } description: {
+                        Text("No files match '\(directoryViewModel.filter)'")
+                    } actions: {
+                        Button("Clear Search") {
+                            directoryViewModel.filter = ""
+                        }
+                    }
                 }
             }
         }

--- a/apple/Fileaway/Views/Viewer/DirectoryView.swift
+++ b/apple/Fileaway/Views/Viewer/DirectoryView.swift
@@ -136,9 +136,15 @@ public struct DirectoryView: View {
         .editable($isEditing)
         .overlay {
             if directoryViewModel.files.isEmpty {
-                ContentUnavailableView("No Files",
-                                       systemImage: "party.popper",
-                                       description: Text("New files will appear here automatically."))
+                if directoryViewModel.filter.isEmpty {
+                    ContentUnavailableView("No Files",
+                                           systemImage: "party.popper",
+                                           description: Text("New files will appear here automatically."))
+                } else {
+                    ContentUnavailableView("No Results",
+                                           systemImage: "magnifyingglass",
+                                           description: Text("No files match '\(directoryViewModel.filter)'"))
+                }
             }
         }
         .progressOverlay(directoryViewModel.isLoading)

--- a/apple/Fileaway/Views/Viewer/DirectoryView.swift
+++ b/apple/Fileaway/Views/Viewer/DirectoryView.swift
@@ -136,21 +136,7 @@ public struct DirectoryView: View {
         .editable($isEditing)
         .overlay {
             if directoryViewModel.files.isEmpty {
-                if directoryViewModel.filter.isEmpty {
-                    ContentUnavailableView("No Files",
-                                           systemImage: "party.popper",
-                                           description: Text("New files will appear here automatically."))
-                } else {
-                    ContentUnavailableView {
-                        Label("No Results", systemImage: "magnifyingglass")
-                    } description: {
-                        Text("No files match '\(directoryViewModel.filter)'")
-                    } actions: {
-                        Button("Clear Search") {
-                            directoryViewModel.filter = ""
-                        }
-                    }
-                }
+                EmptyDirectoryPlaceholderView()
             }
         }
         .progressOverlay(directoryViewModel.isLoading)

--- a/apple/Fileaway/Views/Viewer/EmptyDirectoryPlaceholderView.swift
+++ b/apple/Fileaway/Views/Viewer/EmptyDirectoryPlaceholderView.swift
@@ -1,0 +1,46 @@
+// Copyright (c) 2018-2025 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+struct EmptyDirectoryPlaceholderView: View {
+
+    @Environment(\.isSearching) private var isSearching
+    @Environment(\.dismissSearch) private var dismissSearch
+
+    var body: some View {
+        if isSearching {
+            ContentUnavailableView {
+                Label("No Results", systemImage: "magnifyingglass")
+            } description: {
+                Text("No files match your search")
+            } actions: {
+                Button("Clear Search") {
+                    dismissSearch()
+                }
+            }
+        } else {
+            ContentUnavailableView("No Files",
+                                   systemImage: "party.popper",
+                                   description: Text("New files will appear here automatically."))
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #632.

before

<img width="1782" height="884" alt="screenshot-2025-09-30-17 24 01@2x" src="https://github.com/user-attachments/assets/3f976b0b-f690-4d78-b61d-698cc967e4b5" />

after

<img width="1768" height="848" alt="screenshot-2025-09-30-17 26 23@2x" src="https://github.com/user-attachments/assets/bb752569-7895-4d63-98c8-2b0e1382c6dc" />


(we could also remove the button)

<img width="1780" height="864" alt="screenshot-2025-09-30-17 24 55@2x" src="https://github.com/user-attachments/assets/1f46c397-b5de-48bd-b507-3744cf32daf6" />
